### PR TITLE
feat: add Svelte component library (69 components)

### DIFF
--- a/src/lib/svelte/README.md
+++ b/src/lib/svelte/README.md
@@ -1,0 +1,105 @@
+# Sellsuki Design System — Svelte Components
+
+Svelte port of the Sellsuki Design System components, matching the React version's API and design tokens.
+
+## Structure
+
+```
+src/lib/svelte/
+├── ui/              # Basic UI primitives
+│   ├── Avatar.svelte
+│   ├── Badge.svelte
+│   ├── Button.svelte
+│   ├── Divider.svelte
+│   ├── Heading.svelte
+│   ├── Icon.svelte
+│   ├── Logo.svelte
+│   ├── Spinner.svelte
+│   └── Text.svelte
+├── layout/          # Page structure
+│   ├── TopNavbar.svelte
+│   ├── Sidebar.svelte
+│   ├── SidebarHeader.svelte
+│   ├── SidebarList.svelte
+│   ├── SidebarGroup.svelte
+│   └── SidebarItem.svelte
+├── overlay/         # Modals, dropdowns, toasts
+│   ├── Modal.svelte
+│   ├── Dropdown.svelte
+│   ├── DropdownOption.svelte
+│   └── ToastContainer.svelte
+├── styles/
+│   └── tokens.css   # DSS design tokens (colors, spacing, typography)
+└── index.ts         # Barrel export
+```
+
+## Component Mapping (Svelte ↔ React)
+
+| Svelte | React Equivalent | Status |
+|--------|-----------------|--------|
+| Button | DSButton | ✅ Implemented |
+| Avatar | Avatar | ✅ Implemented |
+| Badge | Badge | ✅ Implemented |
+| Heading | — (new) | ✅ Implemented |
+| Text | — (new) | ✅ Implemented |
+| Icon | — (uses lucide-svelte) | ✅ Implemented |
+| Logo | — (new) | ✅ Implemented |
+| Spinner | Spinner | ✅ Implemented |
+| Divider | Divider | ✅ Implemented |
+| TopNavbar | TopNavbar | ✅ Implemented |
+| Sidebar* | Sidebar | ✅ Implemented |
+| Modal | Modal | ✅ Implemented |
+| Dropdown | Dropdown | ✅ Implemented |
+| ToastContainer | Alert (toast) | ✅ Implemented |
+
+## Usage
+
+```svelte
+<script>
+  import { Button, Badge, Avatar } from '$lib/svelte';
+  import { Modal } from '$lib/svelte/overlay/Modal.svelte';
+</script>
+
+<Button variant="primary" size="md" on:click={handleClick}>
+  Save Changes
+</Button>
+
+<Badge variant="success" size="sm">Active</Badge>
+
+<Avatar src={user.avatar} name={user.name} size="md" />
+```
+
+## Design Tokens
+
+Import `styles/tokens.css` to get all DSS CSS custom properties:
+
+```css
+@import './styles/tokens.css';
+```
+
+Available tokens: `--ssk-colors-*`, `--dss-radius-*`, `--dss-space-*`
+
+## Contributing
+
+1. Each component should match the React version's props and behavior
+2. Use DSS design tokens (not hardcoded values)
+3. Follow Svelte conventions (events via `on:`, slots, reactive `$:`)
+4. Add component to `index.ts` barrel export
+
+## TODO
+
+- [ ] DSInput (text input with validation)
+- [ ] DSCheckbox / DSRadio
+- [ ] Switch
+- [ ] DatePicker
+- [ ] SearchField
+- [ ] DSTable
+- [ ] Tabs
+- [ ] Pagination
+- [ ] Breadcrumb
+- [ ] EmptyState
+- [ ] Skeleton
+- [ ] Card
+- [ ] Tooltip / Popover
+- [ ] Drawer
+- [ ] Stepper

--- a/src/lib/svelte/data/AdvancedDataTable.svelte
+++ b/src/lib/svelte/data/AdvancedDataTable.svelte
@@ -287,12 +287,12 @@
 	.dss-advanced-table {
 		width: 100%;
 		background: white;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.dss-advanced-table.bordered {
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border: 1px solid var(--border, #e5e7eb);
 	}
 
 	/* Toolbar */
@@ -301,7 +301,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: var(--dss-space-4, 16px);
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 
 	/* Bulk actions */
@@ -311,19 +311,19 @@
 		gap: var(--dss-space-4, 16px);
 	}
 	.bulk-count {
-		font-size: var(--dss-font-sm, 13px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-sm, 13px);
+		color: var(--muted-foreground, #6b7280);
 		font-weight: 500;
 	}
 	.bulk-btn {
 		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		background: white;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		color: var(--ssk-colors-text-700, #374151);
 		cursor: pointer;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		transition: background 0.15s;
 	}
 	.bulk-btn:hover {
@@ -334,9 +334,9 @@
 		border-color: #fca5a5;
 	}
 	.bulk-btn.variant-primary {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	/* Column toggle */
@@ -351,10 +351,10 @@
 		width: 32px;
 		height: 32px;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		background: white;
 		cursor: pointer;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		transition: background 0.15s;
 	}
 	.toggle-btn:hover {
@@ -366,8 +366,8 @@
 		top: 100%;
 		margin-top: var(--dss-space-2, 8px);
 		background: white;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		box-shadow: var(--dss-shadow-sm, 0 1px 3px rgba(0,0,0,0.1));
 		padding: var(--dss-space-2, 8px);
 		z-index: 10;
@@ -378,10 +378,10 @@
 		align-items: center;
 		gap: var(--dss-space-2, 8px);
 		padding: var(--dss-space-2, 8px);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		color: var(--ssk-colors-text-700, #374151);
 		cursor: pointer;
-		border-radius: var(--dss-radius-xs, 4px);
+		border-radius: var(--radius-xs, 4px);
 	}
 	.column-option:hover {
 		background: var(--ssk-colors-neutral-50, #f9fafb);
@@ -399,18 +399,18 @@
 	/* Header */
 	thead th {
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		font-weight: 600;
 		text-align: left;
 		white-space: nowrap;
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 	th.sortable {
 		cursor: pointer;
 		user-select: none;
 	}
 	th.sortable:hover {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 	.sticky-header thead th {
 		position: sticky;
@@ -428,30 +428,30 @@
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 	.sort-icon.active {
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 	}
 
 	/* Sizes */
 	.size-sm th, .size-sm td {
 		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		height: 36px;
 	}
 	.size-md th, .size-md td {
 		padding: var(--dss-space-4, 16px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		height: 44px;
 	}
 	.size-lg th, .size-lg td {
 		padding: var(--dss-space-6, 24px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		height: 52px;
 	}
 
 	/* Body */
 	tbody td {
 		color: var(--ssk-colors-text-700, #374151);
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 	.align-left { text-align: left; }
 	.align-center { text-align: center; }
@@ -469,15 +469,15 @@
 	.checkbox-col input[type="checkbox"] {
 		width: 16px;
 		height: 16px;
-		accent-color: var(--ssk-colors-primary-500, #32a9ff);
+		accent-color: var(--primary, #32a9ff);
 		cursor: pointer;
 	}
 
 	/* Empty */
 	.empty-cell { text-align: center; padding: var(--dss-space-24, 96px) var(--dss-space-4, 16px); }
 	.empty-content { display: flex; flex-direction: column; align-items: center; gap: var(--dss-space-2, 8px); }
-	.empty-title { color: var(--ssk-colors-text-500, #6b7280); font-size: var(--dss-font-body, 14px); font-weight: 500; }
-	.empty-desc { color: var(--ssk-colors-text-400, #9ca3af); font-size: var(--dss-font-sm, 13px); }
+	.empty-title { color: var(--muted-foreground, #6b7280); font-size: var(--text-p, 14px); font-weight: 500; }
+	.empty-desc { color: var(--ssk-colors-text-400, #9ca3af); font-size: var(--text-sm, 13px); }
 
 	/* Expanded row */
 	.expanded-row td {
@@ -490,8 +490,8 @@
 	.skeleton-bone {
 		display: inline-block;
 		height: 14px;
-		border-radius: var(--dss-radius-xs, 4px);
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--radius-xs, 4px);
+		background: var(--border, #e5e7eb);
 		animation: dss-adv-table-pulse 1.5s ease-in-out infinite;
 	}
 
@@ -507,7 +507,7 @@
 		gap: var(--dss-space-4, 16px);
 		padding: var(--dss-space-4, 16px);
 		color: #ef4444;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		background: #fef2f2;
 		border-bottom: 1px solid #fca5a5;
 	}
@@ -517,6 +517,6 @@
 		display: flex;
 		justify-content: flex-end;
 		padding: var(--dss-space-4, 16px);
-		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-top: 1px solid var(--border, #e5e7eb);
 	}
 </style>

--- a/src/lib/svelte/data/AdvancedDataTable.svelte
+++ b/src/lib/svelte/data/AdvancedDataTable.svelte
@@ -1,0 +1,522 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import Table from './Table.svelte';
+	import Pagination from './Pagination.svelte';
+
+	type Column = {
+		key: string;
+		header: string;
+		width?: string;
+		align?: 'left' | 'center' | 'right';
+		render?: (value: any, row: Record<string, any>) => string;
+		sortable?: boolean;
+	};
+
+	type PaginationConfig = {
+		page: number;
+		pageSize: number;
+		totalCount: number;
+	};
+
+	type BulkAction = {
+		label: string;
+		variant?: string;
+		onClick: (selectedRows: Record<string, any>[]) => void;
+	};
+
+	export let columns: Column[] = [];
+	export let data: Record<string, any>[] = [];
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let striped: boolean = false;
+	export let hoverable: boolean = true;
+	export let bordered: boolean = false;
+	export let selectable: boolean = false;
+	export let loading: boolean = false;
+	export let emptyMessage: string = 'No data';
+	export let stickyHeader: boolean = false;
+	export let pagination: PaginationConfig | undefined = undefined;
+	export let sortBy: string | undefined = undefined;
+	export let sortOrder: 'asc' | 'desc' | undefined = undefined;
+	export let bulkActions: BulkAction[] = [];
+	export let expandedRowRender: boolean = false;
+	export let showColumnToggle: boolean = false;
+	export let error: string | undefined = undefined;
+	export let emptyDescription: string | undefined = undefined;
+	export let loadingRows: number = 5;
+
+	const dispatch = createEventDispatcher<{
+		pageChange: { page: number };
+		sortChange: { sortBy: string; sortOrder: 'asc' | 'desc' };
+		selectionChange: { selectedRows: Record<string, any>[] };
+		rowClick: { row: Record<string, any>; index: number };
+	}>();
+
+	let selectedRows: Record<string, any>[] = [];
+	let expandedIndex: number | null = null;
+	let hiddenColumns: Set<string> = new Set();
+	let showColumnMenu = false;
+
+	$: visibleColumns = columns.filter((c) => !hiddenColumns.has(c.key));
+	$: totalPages = pagination ? Math.ceil(pagination.totalCount / pagination.pageSize) : 1;
+	$: hasSelection = selectedRows.length > 0;
+
+	function handleSort(col: Column) {
+		if (!col.sortable) return;
+		const newOrder = sortBy === col.key && sortOrder === 'asc' ? 'desc' : 'asc';
+		dispatch('sortChange', { sortBy: col.key, sortOrder: newOrder });
+	}
+
+	function handleSelectionChange(e: CustomEvent<{ selectedRows: Record<string, any>[] }>) {
+		selectedRows = e.detail.selectedRows;
+		dispatch('selectionChange', e.detail);
+	}
+
+	function handleRowClick(e: CustomEvent<{ row: Record<string, any>; index: number }>) {
+		if (expandedRowRender) {
+			expandedIndex = expandedIndex === e.detail.index ? null : e.detail.index;
+		}
+		dispatch('rowClick', e.detail);
+	}
+
+	function handlePageChange(e: CustomEvent<{ page: number }>) {
+		dispatch('pageChange', e.detail);
+	}
+
+	function toggleColumn(key: string) {
+		if (hiddenColumns.has(key)) {
+			hiddenColumns.delete(key);
+		} else {
+			hiddenColumns.add(key);
+		}
+		hiddenColumns = new Set(hiddenColumns);
+	}
+</script>
+
+<div class="dss-advanced-table" class:bordered>
+	<!-- Toolbar -->
+	{#if showColumnToggle || (hasSelection && bulkActions.length > 0)}
+		<div class="table-toolbar">
+			{#if hasSelection && bulkActions.length > 0}
+				<div class="bulk-bar">
+					<span class="bulk-count">{selectedRows.length} selected</span>
+					{#each bulkActions as action}
+						<button
+							class="bulk-btn variant-{action.variant || 'default'}"
+							on:click={() => action.onClick(selectedRows)}
+						>
+							{action.label}
+						</button>
+					{/each}
+				</div>
+			{/if}
+
+			{#if showColumnToggle}
+				<div class="column-toggle">
+					<button
+						class="toggle-btn"
+						on:click={() => (showColumnMenu = !showColumnMenu)}
+						aria-label="Toggle columns"
+					>
+						<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+							<path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+						</svg>
+					</button>
+					{#if showColumnMenu}
+						<div class="column-menu">
+							{#each columns as col}
+								<label class="column-option">
+									<input
+										type="checkbox"
+										checked={!hiddenColumns.has(col.key)}
+										on:change={() => toggleColumn(col.key)}
+									/>
+									{col.header}
+								</label>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Error state -->
+	{#if error}
+		<div class="table-error">
+			<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+				<circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5"/>
+				<path d="M10 6v5M10 13.5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+			</svg>
+			<span>{error}</span>
+		</div>
+	{:else}
+		<!-- Table with sortable headers -->
+		<div class="dss-table-wrapper" class:sticky-header={stickyHeader}>
+			<table class="dss-table size-{size}">
+				<thead>
+					<tr>
+						{#if selectable}
+							<th class="checkbox-col">
+								<input
+									type="checkbox"
+									checked={data.length > 0 && selectedRows.length === data.length}
+									on:change
+									aria-label="Select all"
+								/>
+							</th>
+						{/if}
+						{#each visibleColumns as col}
+							<th
+								style={col.width ? `width: ${col.width}` : ''}
+								class="align-{col.align || 'left'}"
+								class:sortable={col.sortable}
+								on:click={() => handleSort(col)}
+							>
+								<span class="th-content">
+									{col.header}
+									{#if col.sortable}
+										<span class="sort-icon" class:active={sortBy === col.key}>
+											{#if sortBy === col.key && sortOrder === 'asc'}
+												<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+													<path d="M7 3v8M4 6l3-3 3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											{:else if sortBy === col.key && sortOrder === 'desc'}
+												<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+													<path d="M7 11V3M4 8l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											{:else}
+												<svg width="14" height="14" viewBox="0 0 14 14" fill="none" opacity="0.3">
+													<path d="M4 5.5l3-3 3 3M4 8.5l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											{/if}
+										</span>
+									{/if}
+								</span>
+							</th>
+						{/each}
+					</tr>
+				</thead>
+				<tbody>
+					{#if loading}
+						{#each Array(loadingRows) as _, i}
+							<tr class="skeleton-row">
+								{#if selectable}
+									<td class="checkbox-col">
+										<span class="skeleton-bone" style="width: 16px; height: 16px;" />
+									</td>
+								{/if}
+								{#each visibleColumns as col}
+									<td>
+										<span class="skeleton-bone" style="width: {60 + (i * 11) % 30}%;" />
+									</td>
+								{/each}
+							</tr>
+						{/each}
+					{:else if data.length === 0}
+						<tr>
+							<td class="empty-cell" colspan={visibleColumns.length + (selectable ? 1 : 0)}>
+								<div class="empty-content">
+									<span class="empty-title">{emptyMessage}</span>
+									{#if emptyDescription}
+										<span class="empty-desc">{emptyDescription}</span>
+									{/if}
+								</div>
+							</td>
+						</tr>
+					{:else}
+						{#each data as row, index}
+							<tr
+								class:striped={striped && index % 2 === 1}
+								class:hoverable
+								class:selected={selectedRows.includes(row)}
+								on:click={() => handleRowClick(new CustomEvent('rowClick', { detail: { row, index } }))}
+							>
+								{#if selectable}
+									<td class="checkbox-col" on:click|stopPropagation>
+										<input
+											type="checkbox"
+											checked={selectedRows.includes(row)}
+											on:change
+											aria-label="Select row {index + 1}"
+										/>
+									</td>
+								{/if}
+								{#each visibleColumns as col}
+									<td class="align-{col.align || 'left'}">
+										{#if col.render}
+											{@html col.render(row[col.key], row)}
+										{:else}
+											{row[col.key] ?? ''}
+										{/if}
+									</td>
+								{/each}
+							</tr>
+							{#if expandedRowRender && expandedIndex === index}
+								<tr class="expanded-row">
+									<td colspan={visibleColumns.length + (selectable ? 1 : 0)}>
+										<slot name="expandedRow" {row} {index} />
+									</td>
+								</tr>
+							{/if}
+						{/each}
+					{/if}
+				</tbody>
+			</table>
+		</div>
+
+		<!-- Pagination -->
+		{#if pagination}
+			<div class="table-footer">
+				<Pagination
+					currentPage={pagination.page}
+					{totalPages}
+					totalItems={pagination.totalCount}
+					pageSize={pagination.pageSize}
+					{size}
+					showItemsInfo
+					showPageSize
+					on:pageChange={handlePageChange}
+					on:pageSizeChange
+				/>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.dss-advanced-table {
+		width: 100%;
+		background: white;
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+		font-family: 'Inter', sans-serif;
+	}
+	.dss-advanced-table.bordered {
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	/* Toolbar */
+	.table-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--dss-space-4, 16px);
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	/* Bulk actions */
+	.bulk-bar {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-4, 16px);
+	}
+	.bulk-count {
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-weight: 500;
+	}
+	.bulk-btn {
+		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-sm, 6px);
+		background: white;
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-700, #374151);
+		cursor: pointer;
+		font-family: 'Inter', sans-serif;
+		transition: background 0.15s;
+	}
+	.bulk-btn:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.bulk-btn.variant-destructive {
+		color: #ef4444;
+		border-color: #fca5a5;
+	}
+	.bulk-btn.variant-primary {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* Column toggle */
+	.column-toggle {
+		position: relative;
+		margin-left: auto;
+	}
+	.toggle-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-sm, 6px);
+		background: white;
+		cursor: pointer;
+		color: var(--ssk-colors-text-500, #6b7280);
+		transition: background 0.15s;
+	}
+	.toggle-btn:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.column-menu {
+		position: absolute;
+		right: 0;
+		top: 100%;
+		margin-top: var(--dss-space-2, 8px);
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		box-shadow: var(--dss-shadow-sm, 0 1px 3px rgba(0,0,0,0.1));
+		padding: var(--dss-space-2, 8px);
+		z-index: 10;
+		min-width: 160px;
+	}
+	.column-option {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-2, 8px);
+		padding: var(--dss-space-2, 8px);
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-700, #374151);
+		cursor: pointer;
+		border-radius: var(--dss-radius-xs, 4px);
+	}
+	.column-option:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	/* Table wrapper */
+	.dss-table-wrapper {
+		overflow-x: auto;
+	}
+	.dss-table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	/* Header */
+	thead th {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-weight: 600;
+		text-align: left;
+		white-space: nowrap;
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	th.sortable {
+		cursor: pointer;
+		user-select: none;
+	}
+	th.sortable:hover {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.sticky-header thead th {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	.th-content {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-2, 8px);
+	}
+	.sort-icon {
+		display: inline-flex;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	.sort-icon.active {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* Sizes */
+	.size-sm th, .size-sm td {
+		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-caption, 12px);
+		height: 36px;
+	}
+	.size-md th, .size-md td {
+		padding: var(--dss-space-4, 16px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-sm, 13px);
+		height: 44px;
+	}
+	.size-lg th, .size-lg td {
+		padding: var(--dss-space-6, 24px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-body, 14px);
+		height: 52px;
+	}
+
+	/* Body */
+	tbody td {
+		color: var(--ssk-colors-text-700, #374151);
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.align-left { text-align: left; }
+	.align-center { text-align: center; }
+	.align-right { text-align: right; }
+
+	tr.striped td { background: var(--ssk-colors-neutral-50, #f9fafb); }
+	tr.hoverable:hover td { background: var(--ssk-colors-primary-50, #eff6ff); cursor: pointer; }
+	tr.selected td { background: var(--ssk-colors-primary-50, #eff6ff); }
+
+	/* Checkbox column */
+	.checkbox-col {
+		width: 44px;
+		text-align: center;
+	}
+	.checkbox-col input[type="checkbox"] {
+		width: 16px;
+		height: 16px;
+		accent-color: var(--ssk-colors-primary-500, #32a9ff);
+		cursor: pointer;
+	}
+
+	/* Empty */
+	.empty-cell { text-align: center; padding: var(--dss-space-24, 96px) var(--dss-space-4, 16px); }
+	.empty-content { display: flex; flex-direction: column; align-items: center; gap: var(--dss-space-2, 8px); }
+	.empty-title { color: var(--ssk-colors-text-500, #6b7280); font-size: var(--dss-font-body, 14px); font-weight: 500; }
+	.empty-desc { color: var(--ssk-colors-text-400, #9ca3af); font-size: var(--dss-font-sm, 13px); }
+
+	/* Expanded row */
+	.expanded-row td {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		padding: var(--dss-space-4, 16px);
+	}
+
+	/* Skeleton */
+	.skeleton-row td { padding: var(--dss-space-4, 16px); }
+	.skeleton-bone {
+		display: inline-block;
+		height: 14px;
+		border-radius: var(--dss-radius-xs, 4px);
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		animation: dss-adv-table-pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes dss-adv-table-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.4; }
+	}
+
+	/* Error */
+	.table-error {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-4, 16px);
+		padding: var(--dss-space-4, 16px);
+		color: #ef4444;
+		font-size: var(--dss-font-sm, 13px);
+		background: #fef2f2;
+		border-bottom: 1px solid #fca5a5;
+	}
+
+	/* Footer / Pagination */
+	.table-footer {
+		display: flex;
+		justify-content: flex-end;
+		padding: var(--dss-space-4, 16px);
+		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+</style>

--- a/src/lib/svelte/data/EmptyState.svelte
+++ b/src/lib/svelte/data/EmptyState.svelte
@@ -35,7 +35,7 @@
 		flex-direction: column;
 		align-items: center;
 		text-align: center;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Sizes */
@@ -66,8 +66,8 @@
 		font-weight: 600;
 		color: var(--ssk-colors-text-700, #374151);
 	}
-	.size-sm .empty-title { font-size: var(--dss-font-sm, 13px); }
-	.size-md .empty-title { font-size: var(--dss-font-body, 14px); }
+	.size-sm .empty-title { font-size: var(--text-sm, 13px); }
+	.size-md .empty-title { font-size: var(--text-p, 14px); }
 	.size-lg .empty-title { font-size: 16px; }
 
 	/* Description */
@@ -77,9 +77,9 @@
 		max-width: 320px;
 		line-height: 1.5;
 	}
-	.size-sm .empty-description { font-size: var(--dss-font-caption, 12px); }
-	.size-md .empty-description { font-size: var(--dss-font-sm, 13px); }
-	.size-lg .empty-description { font-size: var(--dss-font-body, 14px); }
+	.size-sm .empty-description { font-size: var(--text-caption, 12px); }
+	.size-md .empty-description { font-size: var(--text-sm, 13px); }
+	.size-lg .empty-description { font-size: var(--text-p, 14px); }
 
 	/* Actions */
 	.empty-action {

--- a/src/lib/svelte/data/EmptyState.svelte
+++ b/src/lib/svelte/data/EmptyState.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	export let title: string;
+	export let description: string | undefined = undefined;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+</script>
+
+<div class="dss-empty-state size-{size}">
+	<div class="empty-icon">
+		<slot name="icon">
+			<svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+				<rect x="4" y="8" width="40" height="32" rx="4" stroke="currentColor" stroke-width="2" stroke-dasharray="4 3"/>
+				<path d="M18 22h12M21 28h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+			</svg>
+		</slot>
+	</div>
+
+	<h3 class="empty-title">{title}</h3>
+
+	{#if description}
+		<p class="empty-description">{description}</p>
+	{/if}
+
+	<div class="empty-action">
+		<slot name="action" />
+	</div>
+
+	<div class="empty-secondary">
+		<slot name="secondaryAction" />
+	</div>
+</div>
+
+<style>
+	.dss-empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Sizes */
+	.size-sm {
+		padding: var(--dss-space-8, 32px) var(--dss-space-4, 16px);
+		gap: var(--dss-space-2, 8px);
+	}
+	.size-md {
+		padding: var(--dss-space-16, 64px) var(--dss-space-8, 32px);
+		gap: var(--dss-space-4, 16px);
+	}
+	.size-lg {
+		padding: var(--dss-space-24, 96px) var(--dss-space-12, 48px);
+		gap: var(--dss-space-6, 24px);
+	}
+
+	/* Icon */
+	.empty-icon {
+		color: var(--ssk-colors-neutral-300, #d1d5db);
+		margin-bottom: var(--dss-space-2, 8px);
+	}
+	.size-sm .empty-icon { transform: scale(0.75); }
+	.size-lg .empty-icon { transform: scale(1.25); }
+
+	/* Title */
+	.empty-title {
+		margin: 0;
+		font-weight: 600;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.size-sm .empty-title { font-size: var(--dss-font-sm, 13px); }
+	.size-md .empty-title { font-size: var(--dss-font-body, 14px); }
+	.size-lg .empty-title { font-size: 16px; }
+
+	/* Description */
+	.empty-description {
+		margin: 0;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		max-width: 320px;
+		line-height: 1.5;
+	}
+	.size-sm .empty-description { font-size: var(--dss-font-caption, 12px); }
+	.size-md .empty-description { font-size: var(--dss-font-sm, 13px); }
+	.size-lg .empty-description { font-size: var(--dss-font-body, 14px); }
+
+	/* Actions */
+	.empty-action {
+		margin-top: var(--dss-space-4, 16px);
+	}
+	.empty-action:empty {
+		display: none;
+	}
+
+	.empty-secondary {
+		margin-top: var(--dss-space-2, 8px);
+	}
+	.empty-secondary:empty {
+		display: none;
+	}
+</style>

--- a/src/lib/svelte/data/FilterBar.svelte
+++ b/src/lib/svelte/data/FilterBar.svelte
@@ -170,15 +170,15 @@
 		height: 36px;
 		padding: 0 12px 0 32px;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-900, #111827);
+		border-radius: var(--radius-md, 8px);
+		font-size: var(--text-p, 14px);
+		color: var(--foreground, #111827);
 		outline: none;
 		min-width: 200px;
 		transition: border-color 0.15s;
 	}
 	.dss-filter-bar-search-input:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
 	}
 	.dss-filter-bar-search-input::placeholder {
@@ -197,8 +197,8 @@
 		padding: 0 12px;
 		background: white;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
-		font-size: var(--dss-font-body, 14px);
+		border-radius: var(--radius-md, 8px);
+		font-size: var(--text-p, 14px);
 		color: var(--ssk-colors-text-700, #374151);
 		cursor: pointer;
 		transition: border-color 0.15s, background 0.15s;
@@ -208,7 +208,7 @@
 		background: var(--ssk-colors-neutral-50, #f9fafb);
 	}
 	.dss-filter-btn.active {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		color: var(--ssk-colors-primary-700, #0b6bcb);
 		background: var(--ssk-colors-primary-50, #eff8ff);
 	}
@@ -220,9 +220,9 @@
 		min-width: 18px;
 		height: 18px;
 		padding: 0 5px;
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		font-size: 11px;
 		font-weight: 600;
 		line-height: 1;
@@ -238,8 +238,8 @@
 		left: 0;
 		min-width: 180px;
 		background: white;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 		z-index: 50;
 		padding: var(--dss-space-4, 4px);
@@ -253,10 +253,10 @@
 		padding: var(--dss-space-8, 8px) var(--dss-space-8, 8px);
 		border: none;
 		background: transparent;
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		color: var(--ssk-colors-text-700, #374151);
 		cursor: pointer;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		text-align: left;
 		transition: background 0.1s;
 	}
@@ -280,12 +280,12 @@
 		transition: background 0.1s, border-color 0.1s;
 	}
 	.dss-filter-checkbox.checked {
-		background: var(--ssk-colors-primary-500, #32a9ff);
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	.dss-filter-dropdown-footer {
-		border-top: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-top: 1px solid var(--muted, #f3f4f6);
 		margin-top: var(--dss-space-4, 4px);
 		padding-top: var(--dss-space-4, 4px);
 	}
@@ -294,14 +294,14 @@
 		padding: var(--dss-space-8, 8px);
 		border: none;
 		background: transparent;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 		cursor: pointer;
 		text-align: center;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 	}
 	.dss-filter-clear:hover {
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 </style>

--- a/src/lib/svelte/data/FilterBar.svelte
+++ b/src/lib/svelte/data/FilterBar.svelte
@@ -1,0 +1,307 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let filters: {
+		key: string;
+		label: string;
+		type: 'single' | 'multi';
+		options: { label: string; value: string }[];
+	}[] = [];
+	export let searchPlaceholder: string = 'Search...';
+	export let showSearch: boolean = true;
+	export let value: { search?: string; filters: Record<string, string | string[]> } | undefined = undefined;
+
+	const dispatch = createEventDispatcher();
+
+	let search = value?.search ?? '';
+	let filterValues: Record<string, string | string[]> = value?.filters ?? {};
+	let openDropdown: string | null = null;
+
+	function emitChange() {
+		const result = { search, filters: filterValues };
+		value = result;
+		dispatch('filterChange', result);
+	}
+
+	function handleSearchInput() {
+		emitChange();
+	}
+
+	function toggleDropdown(key: string) {
+		openDropdown = openDropdown === key ? null : key;
+	}
+
+	function selectOption(filterKey: string, optionValue: string, type: 'single' | 'multi') {
+		if (type === 'single') {
+			if (filterValues[filterKey] === optionValue) {
+				delete filterValues[filterKey];
+				filterValues = { ...filterValues };
+			} else {
+				filterValues = { ...filterValues, [filterKey]: optionValue };
+			}
+			openDropdown = null;
+		} else {
+			const current = (filterValues[filterKey] as string[]) || [];
+			const index = current.indexOf(optionValue);
+			if (index >= 0) {
+				const next = current.filter((v) => v !== optionValue);
+				if (next.length === 0) {
+					delete filterValues[filterKey];
+					filterValues = { ...filterValues };
+				} else {
+					filterValues = { ...filterValues, [filterKey]: next };
+				}
+			} else {
+				filterValues = { ...filterValues, [filterKey]: [...current, optionValue] };
+			}
+		}
+		emitChange();
+	}
+
+	function isSelected(filterKey: string, optionValue: string, type: 'single' | 'multi'): boolean {
+		if (type === 'single') return filterValues[filterKey] === optionValue;
+		return ((filterValues[filterKey] as string[]) || []).includes(optionValue);
+	}
+
+	function getActiveCount(filterKey: string, type: 'single' | 'multi'): number {
+		if (type === 'single') return filterValues[filterKey] ? 1 : 0;
+		return ((filterValues[filterKey] as string[]) || []).length;
+	}
+
+	function clearFilter(filterKey: string) {
+		delete filterValues[filterKey];
+		filterValues = { ...filterValues };
+		emitChange();
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.dss-filter-dropdown-wrapper')) {
+			openDropdown = null;
+		}
+	}
+</script>
+
+<svelte:window on:click={handleClickOutside} />
+
+<div class="dss-filter-bar">
+	{#if showSearch}
+		<div class="dss-filter-bar-search">
+			<svg class="dss-filter-bar-search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+				<path d="M7 12A5 5 0 107 2a5 5 0 000 10zM13 13l-3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+			</svg>
+			<input
+				type="text"
+				class="dss-filter-bar-search-input"
+				placeholder={searchPlaceholder}
+				bind:value={search}
+				on:input={handleSearchInput}
+			/>
+		</div>
+	{/if}
+
+	{#each filters as filter}
+		{@const count = getActiveCount(filter.key, filter.type)}
+		<div class="dss-filter-dropdown-wrapper">
+			<button
+				class="dss-filter-btn"
+				class:active={count > 0}
+				on:click|stopPropagation={() => toggleDropdown(filter.key)}
+			>
+				{filter.label}
+				{#if count > 0}
+					<span class="dss-filter-badge">{count}</span>
+				{/if}
+				<svg class="dss-filter-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
+					<path d="M3 4.5l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+			{#if openDropdown === filter.key}
+				<div class="dss-filter-dropdown" on:click|stopPropagation>
+					{#each filter.options as option}
+						<button
+							class="dss-filter-option"
+							class:selected={isSelected(filter.key, option.value, filter.type)}
+							on:click={() => selectOption(filter.key, option.value, filter.type)}
+						>
+							{#if filter.type === 'multi'}
+								<span class="dss-filter-checkbox" class:checked={isSelected(filter.key, option.value, filter.type)}>
+									{#if isSelected(filter.key, option.value, filter.type)}
+										<svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+											<path d="M2 5l2 2 4-4" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+										</svg>
+									{/if}
+								</span>
+							{/if}
+							{option.label}
+						</button>
+					{/each}
+					{#if count > 0}
+						<div class="dss-filter-dropdown-footer">
+							<button class="dss-filter-clear" on:click={() => clearFilter(filter.key)}>Clear</button>
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-filter-bar {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		flex-wrap: wrap;
+	}
+
+	.dss-filter-bar-search {
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+	.dss-filter-bar-search-icon {
+		position: absolute;
+		left: 10px;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		pointer-events: none;
+	}
+	.dss-filter-bar-search-input {
+		height: 36px;
+		padding: 0 12px 0 32px;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-900, #111827);
+		outline: none;
+		min-width: 200px;
+		transition: border-color 0.15s;
+	}
+	.dss-filter-bar-search-input:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
+	}
+	.dss-filter-bar-search-input::placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.dss-filter-dropdown-wrapper {
+		position: relative;
+	}
+
+	.dss-filter-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		height: 36px;
+		padding: 0 12px;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-700, #374151);
+		cursor: pointer;
+		transition: border-color 0.15s, background 0.15s;
+		white-space: nowrap;
+	}
+	.dss-filter-btn:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.dss-filter-btn.active {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--ssk-colors-primary-700, #0b6bcb);
+		background: var(--ssk-colors-primary-50, #eff8ff);
+	}
+
+	.dss-filter-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 5px;
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		border-radius: var(--dss-radius-full, 9999px);
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	.dss-filter-chevron {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.dss-filter-dropdown {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		min-width: 180px;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		z-index: 50;
+		padding: var(--dss-space-4, 4px);
+	}
+
+	.dss-filter-option {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		width: 100%;
+		padding: var(--dss-space-8, 8px) var(--dss-space-8, 8px);
+		border: none;
+		background: transparent;
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-700, #374151);
+		cursor: pointer;
+		border-radius: var(--dss-radius-sm, 4px);
+		text-align: left;
+		transition: background 0.1s;
+	}
+	.dss-filter-option:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.dss-filter-option.selected {
+		color: var(--ssk-colors-primary-700, #0b6bcb);
+		font-weight: 500;
+	}
+
+	.dss-filter-checkbox {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border: 1.5px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: 3px;
+		flex-shrink: 0;
+		transition: background 0.1s, border-color 0.1s;
+	}
+	.dss-filter-checkbox.checked {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.dss-filter-dropdown-footer {
+		border-top: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		margin-top: var(--dss-space-4, 4px);
+		padding-top: var(--dss-space-4, 4px);
+	}
+	.dss-filter-clear {
+		width: 100%;
+		padding: var(--dss-space-8, 8px);
+		border: none;
+		background: transparent;
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		cursor: pointer;
+		text-align: center;
+		border-radius: var(--dss-radius-sm, 4px);
+	}
+	.dss-filter-clear:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+</style>

--- a/src/lib/svelte/data/Pagination.svelte
+++ b/src/lib/svelte/data/Pagination.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let currentPage: number = 1;
+	export let totalPages: number = 1;
+	export let siblingCount: number = 1;
+	export let showFirstLast: boolean = true;
+	export let showPrevNext: boolean = true;
+	export let showPageSize: boolean = false;
+	export let pageSizeOptions: number[] = [10, 20, 50];
+	export let pageSize: number = 10;
+	export let totalItems: number | undefined = undefined;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let variant: 'default' | 'outlined' | 'filled' | 'minimal' = 'default';
+	export let disabled: boolean = false;
+	export let showPageInfo: boolean = false;
+	export let showItemsInfo: boolean = false;
+
+	const dispatch = createEventDispatcher<{
+		pageChange: { page: number };
+		pageSizeChange: { pageSize: number };
+	}>();
+
+	function range(start: number, end: number): number[] {
+		const result: number[] = [];
+		for (let i = start; i <= end; i++) result.push(i);
+		return result;
+	}
+
+	$: pages = (() => {
+		const totalPageNumbers = siblingCount * 2 + 3;
+		if (totalPages <= totalPageNumbers + 2) {
+			return range(1, totalPages);
+		}
+
+		const leftSiblingIndex = Math.max(currentPage - siblingCount, 1);
+		const rightSiblingIndex = Math.min(currentPage + siblingCount, totalPages);
+
+		const showLeftEllipsis = leftSiblingIndex > 2;
+		const showRightEllipsis = rightSiblingIndex < totalPages - 1;
+
+		if (!showLeftEllipsis && showRightEllipsis) {
+			const leftRange = range(1, 3 + 2 * siblingCount);
+			return [...leftRange, -1, totalPages];
+		}
+
+		if (showLeftEllipsis && !showRightEllipsis) {
+			const rightRange = range(totalPages - (2 + 2 * siblingCount), totalPages);
+			return [1, -1, ...rightRange];
+		}
+
+		const middleRange = range(leftSiblingIndex, rightSiblingIndex);
+		return [1, -1, ...middleRange, -2, totalPages];
+	})();
+
+	function goToPage(page: number) {
+		if (disabled || page < 1 || page > totalPages || page === currentPage) return;
+		dispatch('pageChange', { page });
+	}
+
+	function handlePageSizeChange(e: Event) {
+		const target = e.target as HTMLSelectElement;
+		const newSize = parseInt(target.value, 10);
+		dispatch('pageSizeChange', { pageSize: newSize });
+	}
+
+	$: startItem = totalItems !== undefined ? (currentPage - 1) * pageSize + 1 : 0;
+	$: endItem = totalItems !== undefined ? Math.min(currentPage * pageSize, totalItems) : 0;
+</script>
+
+<nav class="dss-pagination size-{size} variant-{variant}" class:disabled aria-label="Pagination">
+	{#if showPageSize}
+		<div class="page-size">
+			<span class="page-size-label">Rows per page:</span>
+			<select value={pageSize} on:change={handlePageSizeChange} {disabled}>
+				{#each pageSizeOptions as opt}
+					<option value={opt}>{opt}</option>
+				{/each}
+			</select>
+		</div>
+	{/if}
+
+	{#if showItemsInfo && totalItems !== undefined}
+		<span class="items-info">{startItem}-{endItem} of {totalItems}</span>
+	{/if}
+
+	<div class="page-buttons">
+		{#if showFirstLast}
+			<button
+				class="page-btn"
+				disabled={disabled || currentPage === 1}
+				on:click={() => goToPage(1)}
+				aria-label="First page"
+			>
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+					<path d="M11 12L7 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M7 12L3 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+		{/if}
+
+		{#if showPrevNext}
+			<button
+				class="page-btn"
+				disabled={disabled || currentPage === 1}
+				on:click={() => goToPage(currentPage - 1)}
+				aria-label="Previous page"
+			>
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+					<path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+		{/if}
+
+		{#each pages as page, i}
+			{#if page < 0}
+				<span class="ellipsis">...</span>
+			{:else}
+				<button
+					class="page-btn"
+					class:active={page === currentPage}
+					disabled={disabled}
+					on:click={() => goToPage(page)}
+					aria-label="Page {page}"
+					aria-current={page === currentPage ? 'page' : undefined}
+				>
+					{page}
+				</button>
+			{/if}
+		{/each}
+
+		{#if showPrevNext}
+			<button
+				class="page-btn"
+				disabled={disabled || currentPage === totalPages}
+				on:click={() => goToPage(currentPage + 1)}
+				aria-label="Next page"
+			>
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+					<path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+		{/if}
+
+		{#if showFirstLast}
+			<button
+				class="page-btn"
+				disabled={disabled || currentPage === totalPages}
+				on:click={() => goToPage(totalPages)}
+				aria-label="Last page"
+			>
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+					<path d="M5 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<path d="M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+		{/if}
+	</div>
+
+	{#if showPageInfo}
+		<span class="page-info">Page {currentPage} of {totalPages}</span>
+	{/if}
+</nav>
+
+<style>
+	.dss-pagination {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-4, 16px);
+		font-family: 'Inter', sans-serif;
+	}
+	.dss-pagination.disabled {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
+	.page-buttons {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-2, 8px);
+	}
+
+	/* Button base */
+	.page-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-family: 'Inter', sans-serif;
+		font-weight: 500;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
+		border-radius: var(--dss-radius-sm, 6px);
+	}
+	.page-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+	.page-btn:not(:disabled):hover {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	/* Active */
+	.page-btn.active {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+	}
+	.page-btn.active:hover {
+		background: var(--ssk-colors-primary-600, #1b8bf5);
+		color: white;
+	}
+
+	/* Variant: outlined */
+	.variant-outlined .page-btn {
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.variant-outlined .page-btn.active {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* Variant: filled */
+	.variant-filled .page-btn {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.variant-filled .page-btn.active {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* Variant: minimal */
+	.variant-minimal .page-btn.active {
+		background: none;
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		font-weight: 700;
+	}
+
+	/* Sizes */
+	.size-sm .page-btn {
+		min-width: 28px;
+		height: 28px;
+		font-size: var(--dss-font-caption, 12px);
+	}
+	.size-md .page-btn {
+		min-width: 32px;
+		height: 32px;
+		font-size: var(--dss-font-sm, 13px);
+	}
+	.size-lg .page-btn {
+		min-width: 40px;
+		height: 40px;
+		font-size: var(--dss-font-body, 14px);
+	}
+
+	.ellipsis {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 28px;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		font-size: var(--dss-font-sm, 13px);
+		user-select: none;
+	}
+
+	/* Page size selector */
+	.page-size {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-2, 8px);
+	}
+	.page-size-label {
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		white-space: nowrap;
+	}
+	.page-size select {
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-sm, 6px);
+		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-700, #374151);
+		background: white;
+		cursor: pointer;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Info text */
+	.items-info,
+	.page-info {
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		white-space: nowrap;
+	}
+</style>

--- a/src/lib/svelte/data/Pagination.svelte
+++ b/src/lib/svelte/data/Pagination.svelte
@@ -167,7 +167,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--dss-space-4, 16px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.dss-pagination.disabled {
 		opacity: 0.5;
@@ -188,24 +188,24 @@
 		border: none;
 		background: none;
 		cursor: pointer;
-		color: var(--ssk-colors-text-500, #6b7280);
-		font-family: 'Inter', sans-serif;
+		color: var(--muted-foreground, #6b7280);
+		font-family: var(--font-label);
 		font-weight: 500;
 		transition: background 0.15s, color 0.15s, border-color 0.15s;
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 	}
 	.page-btn:disabled {
 		opacity: 0.4;
 		cursor: not-allowed;
 	}
 	.page-btn:not(:disabled):hover {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-700, #374151);
 	}
 
 	/* Active */
 	.page-btn.active {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
 	}
 	.page-btn.active:hover {
@@ -215,10 +215,10 @@
 
 	/* Variant: outlined */
 	.variant-outlined .page-btn {
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border: 1px solid var(--border, #e5e7eb);
 	}
 	.variant-outlined .page-btn.active {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	/* Variant: filled */
@@ -226,13 +226,13 @@
 		background: var(--ssk-colors-neutral-50, #f9fafb);
 	}
 	.variant-filled .page-btn.active {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 	}
 
 	/* Variant: minimal */
 	.variant-minimal .page-btn.active {
 		background: none;
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 		font-weight: 700;
 	}
 
@@ -240,17 +240,17 @@
 	.size-sm .page-btn {
 		min-width: 28px;
 		height: 28px;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 	}
 	.size-md .page-btn {
 		min-width: 32px;
 		height: 32px;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 	}
 	.size-lg .page-btn {
 		min-width: 40px;
 		height: 40px;
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 	}
 
 	.ellipsis {
@@ -259,7 +259,7 @@
 		justify-content: center;
 		min-width: 28px;
 		color: var(--ssk-colors-text-400, #9ca3af);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		user-select: none;
 	}
 
@@ -270,26 +270,26 @@
 		gap: var(--dss-space-2, 8px);
 	}
 	.page-size-label {
-		font-size: var(--dss-font-sm, 13px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-sm, 13px);
+		color: var(--muted-foreground, #6b7280);
 		white-space: nowrap;
 	}
 	.page-size select {
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		color: var(--ssk-colors-text-700, #374151);
 		background: white;
 		cursor: pointer;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Info text */
 	.items-info,
 	.page-info {
-		font-size: var(--dss-font-sm, 13px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-sm, 13px);
+		color: var(--muted-foreground, #6b7280);
 		white-space: nowrap;
 	}
 </style>

--- a/src/lib/svelte/data/Skeleton.svelte
+++ b/src/lib/svelte/data/Skeleton.svelte
@@ -14,17 +14,17 @@
 <style>
 	.dss-skeleton {
 		display: inline-block;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 
 	.variant-text {
-		border-radius: var(--dss-radius-xs, 4px);
+		border-radius: var(--radius-xs, 4px);
 	}
 	.variant-circular {
 		border-radius: 50%;
 	}
 	.variant-rectangular {
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 	}
 
 	.animate {

--- a/src/lib/svelte/data/Skeleton.svelte
+++ b/src/lib/svelte/data/Skeleton.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	export let width: string | undefined = undefined;
+	export let height: string = '16px';
+	export let variant: 'text' | 'circular' | 'rectangular' = 'text';
+	export let animate: boolean = true;
+</script>
+
+<span
+	class="dss-skeleton variant-{variant}"
+	class:animate
+	style="width: {width || (variant === 'circular' ? height : '100%')}; height: {height};"
+/>
+
+<style>
+	.dss-skeleton {
+		display: inline-block;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.variant-text {
+		border-radius: var(--dss-radius-xs, 4px);
+	}
+	.variant-circular {
+		border-radius: 50%;
+	}
+	.variant-rectangular {
+		border-radius: var(--dss-radius-sm, 6px);
+	}
+
+	.animate {
+		animation: dss-skeleton-pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes dss-skeleton-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.4; }
+	}
+</style>

--- a/src/lib/svelte/data/SkeletonCard.svelte
+++ b/src/lib/svelte/data/SkeletonCard.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import Skeleton from './Skeleton.svelte';
+
+	export let animate: boolean = true;
+</script>
+
+<div class="dss-skeleton-card">
+	<Skeleton variant="rectangular" height="140px" {animate} />
+	<div class="card-body">
+		<Skeleton variant="text" width="70%" height="18px" {animate} />
+		<Skeleton variant="text" width="100%" height="14px" {animate} />
+		<Skeleton variant="text" width="85%" height="14px" {animate} />
+		<div class="card-footer">
+			<Skeleton variant="circular" width="28px" height="28px" {animate} />
+			<Skeleton variant="text" width="100px" height="14px" {animate} />
+		</div>
+	</div>
+</div>
+
+<style>
+	.dss-skeleton-card {
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+		background: white;
+	}
+	.card-body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 16px);
+		padding: var(--dss-space-4, 16px);
+	}
+	.card-footer {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-4, 16px);
+		margin-top: var(--dss-space-2, 8px);
+	}
+</style>

--- a/src/lib/svelte/data/SkeletonCard.svelte
+++ b/src/lib/svelte/data/SkeletonCard.svelte
@@ -19,8 +19,8 @@
 
 <style>
 	.dss-skeleton-card {
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
 		background: white;
 	}

--- a/src/lib/svelte/data/SkeletonList.svelte
+++ b/src/lib/svelte/data/SkeletonList.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import Skeleton from './Skeleton.svelte';
+
+	export let rows: number = 5;
+	export let animate: boolean = true;
+	export let showAvatar: boolean = true;
+</script>
+
+<div class="dss-skeleton-list">
+	{#each Array(rows) as _, i}
+		<div class="list-item">
+			{#if showAvatar}
+				<Skeleton variant="circular" width="36px" height="36px" {animate} />
+			{/if}
+			<div class="list-content">
+				<Skeleton variant="text" width="{55 + (i * 13) % 35}%" height="14px" {animate} />
+				<Skeleton variant="text" width="{40 + (i * 7) % 25}%" height="12px" {animate} />
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-skeleton-list {
+		display: flex;
+		flex-direction: column;
+	}
+	.list-item {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-4, 16px);
+		padding: var(--dss-space-4, 16px) 0;
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.list-item:last-child {
+		border-bottom: none;
+	}
+	.list-content {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-2, 8px);
+	}
+</style>

--- a/src/lib/svelte/data/SkeletonList.svelte
+++ b/src/lib/svelte/data/SkeletonList.svelte
@@ -30,7 +30,7 @@
 		align-items: center;
 		gap: var(--dss-space-4, 16px);
 		padding: var(--dss-space-4, 16px) 0;
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 	.list-item:last-child {
 		border-bottom: none;

--- a/src/lib/svelte/data/SkeletonTable.svelte
+++ b/src/lib/svelte/data/SkeletonTable.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import Skeleton from './Skeleton.svelte';
+
+	export let rows: number = 5;
+	export let columns: number = 4;
+	export let animate: boolean = true;
+	export let showHeader: boolean = true;
+</script>
+
+<div class="dss-skeleton-table">
+	{#if showHeader}
+		<div class="table-header">
+			{#each Array(columns) as _, c}
+				<div class="table-cell">
+					<Skeleton variant="text" width="{50 + (c * 17) % 40}%" height="12px" {animate} />
+				</div>
+			{/each}
+		</div>
+	{/if}
+	{#each Array(rows) as _, r}
+		<div class="table-row">
+			{#each Array(columns) as _, c}
+				<div class="table-cell">
+					<Skeleton variant="text" width="{45 + ((r + c) * 13) % 40}%" height="14px" {animate} />
+				</div>
+			{/each}
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-skeleton-table {
+		width: 100%;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+	}
+	.table-header {
+		display: flex;
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.table-row {
+		display: flex;
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.table-row:last-child {
+		border-bottom: none;
+	}
+	.table-cell {
+		flex: 1;
+		padding: var(--dss-space-4, 16px);
+	}
+</style>

--- a/src/lib/svelte/data/SkeletonTable.svelte
+++ b/src/lib/svelte/data/SkeletonTable.svelte
@@ -31,18 +31,18 @@
 <style>
 	.dss-skeleton-table {
 		width: 100%;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
 	}
 	.table-header {
 		display: flex;
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 	.table-row {
 		display: flex;
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 	.table-row:last-child {
 		border-bottom: none;

--- a/src/lib/svelte/data/Table.svelte
+++ b/src/lib/svelte/data/Table.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	type Column = {
+		key: string;
+		header: string;
+		width?: string;
+		align?: 'left' | 'center' | 'right';
+		render?: (value: any, row: Record<string, any>) => string;
+	};
+
+	export let columns: Column[] = [];
+	export let data: Record<string, any>[] = [];
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let striped: boolean = false;
+	export let hoverable: boolean = true;
+	export let bordered: boolean = false;
+	export let selectable: boolean = false;
+	export let loading: boolean = false;
+	export let emptyMessage: string = 'No data';
+	export let stickyHeader: boolean = false;
+
+	const dispatch = createEventDispatcher<{
+		rowClick: { row: Record<string, any>; index: number };
+		selectionChange: { selectedRows: Record<string, any>[] };
+	}>();
+
+	let selectedIndices: Set<number> = new Set();
+
+	$: allSelected = data.length > 0 && selectedIndices.size === data.length;
+	$: someSelected = selectedIndices.size > 0 && selectedIndices.size < data.length;
+
+	function handleRowClick(row: Record<string, any>, index: number) {
+		dispatch('rowClick', { row, index });
+	}
+
+	function toggleRow(index: number) {
+		if (selectedIndices.has(index)) {
+			selectedIndices.delete(index);
+		} else {
+			selectedIndices.add(index);
+		}
+		selectedIndices = new Set(selectedIndices);
+		dispatch('selectionChange', {
+			selectedRows: data.filter((_, i) => selectedIndices.has(i))
+		});
+	}
+
+	function toggleAll() {
+		if (allSelected) {
+			selectedIndices = new Set();
+		} else {
+			selectedIndices = new Set(data.map((_, i) => i));
+		}
+		dispatch('selectionChange', {
+			selectedRows: data.filter((_, i) => selectedIndices.has(i))
+		});
+	}
+
+	const skeletonRows = Array(5).fill(null);
+</script>
+
+<div
+	class="dss-table-wrapper"
+	class:bordered
+	class:sticky-header={stickyHeader}
+>
+	<table class="dss-table size-{size}">
+		<thead>
+			<tr>
+				{#if selectable}
+					<th class="checkbox-col">
+						<input
+							type="checkbox"
+							checked={allSelected}
+							indeterminate={someSelected}
+							on:change={toggleAll}
+							aria-label="Select all rows"
+						/>
+					</th>
+				{/if}
+				{#each columns as col}
+					<th
+						style={col.width ? `width: ${col.width}` : ''}
+						class="align-{col.align || 'left'}"
+					>
+						{col.header}
+					</th>
+				{/each}
+			</tr>
+		</thead>
+		<tbody>
+			{#if loading}
+				{#each skeletonRows as _, i}
+					<tr class="skeleton-row">
+						{#if selectable}
+							<td class="checkbox-col">
+								<span class="skeleton-bone" style="width: 16px; height: 16px;" />
+							</td>
+						{/if}
+						{#each columns as col}
+							<td>
+								<span class="skeleton-bone" style="width: {60 + (i * 7) % 30}%;" />
+							</td>
+						{/each}
+					</tr>
+				{/each}
+			{:else if data.length === 0}
+				<tr>
+					<td
+						class="empty-cell"
+						colspan={columns.length + (selectable ? 1 : 0)}
+					>
+						{emptyMessage}
+					</td>
+				</tr>
+			{:else}
+				{#each data as row, index}
+					<tr
+						class:striped={striped && index % 2 === 1}
+						class:hoverable
+						class:selected={selectedIndices.has(index)}
+						on:click={() => handleRowClick(row, index)}
+					>
+						{#if selectable}
+							<td class="checkbox-col" on:click|stopPropagation>
+								<input
+									type="checkbox"
+									checked={selectedIndices.has(index)}
+									on:change={() => toggleRow(index)}
+									aria-label="Select row {index + 1}"
+								/>
+							</td>
+						{/if}
+						{#each columns as col}
+							<td class="align-{col.align || 'left'}">
+								{#if col.render}
+									{@html col.render(row[col.key], row)}
+								{:else}
+									{row[col.key] ?? ''}
+								{/if}
+							</td>
+						{/each}
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.dss-table-wrapper {
+		width: 100%;
+		overflow-x: auto;
+		border-radius: var(--dss-radius-md, 8px);
+		background: white;
+	}
+	.dss-table-wrapper.bordered {
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.dss-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Header */
+	thead th {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-weight: 600;
+		text-align: left;
+		white-space: nowrap;
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.sticky-header thead th {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	/* Size variants */
+	.size-sm th,
+	.size-sm td {
+		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-caption, 12px);
+		height: 36px;
+	}
+	.size-md th,
+	.size-md td {
+		padding: var(--dss-space-4, 16px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-sm, 13px);
+		height: 44px;
+	}
+	.size-lg th,
+	.size-lg td {
+		padding: var(--dss-space-6, 24px) var(--dss-space-4, 16px);
+		font-size: var(--dss-font-body, 14px);
+		height: 52px;
+	}
+
+	/* Body */
+	tbody td {
+		color: var(--ssk-colors-text-700, #374151);
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	/* Alignment */
+	.align-left { text-align: left; }
+	.align-center { text-align: center; }
+	.align-right { text-align: right; }
+
+	/* Striped */
+	tr.striped td {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	/* Hoverable */
+	tr.hoverable:hover td {
+		background: var(--ssk-colors-primary-50, #eff6ff);
+		cursor: pointer;
+	}
+
+	/* Selected */
+	tr.selected td {
+		background: var(--ssk-colors-primary-50, #eff6ff);
+	}
+
+	/* Checkbox column */
+	.checkbox-col {
+		width: 44px;
+		text-align: center;
+	}
+	.checkbox-col input[type="checkbox"] {
+		width: 16px;
+		height: 16px;
+		accent-color: var(--ssk-colors-primary-500, #32a9ff);
+		cursor: pointer;
+	}
+
+	/* Empty */
+	.empty-cell {
+		text-align: center;
+		padding: var(--dss-space-24, 96px) var(--dss-space-4, 16px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		font-size: var(--dss-font-body, 14px);
+	}
+
+	/* Skeleton */
+	.skeleton-row td {
+		padding: var(--dss-space-4, 16px);
+	}
+	.skeleton-bone {
+		display: inline-block;
+		height: 14px;
+		border-radius: var(--dss-radius-xs, 4px);
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		animation: dss-table-pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes dss-table-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.4; }
+	}
+</style>

--- a/src/lib/svelte/data/Table.svelte
+++ b/src/lib/svelte/data/Table.svelte
@@ -152,27 +152,27 @@
 	.dss-table-wrapper {
 		width: 100%;
 		overflow-x: auto;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		background: white;
 	}
 	.dss-table-wrapper.bordered {
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border: 1px solid var(--border, #e5e7eb);
 	}
 
 	.dss-table {
 		width: 100%;
 		border-collapse: collapse;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Header */
 	thead th {
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		font-weight: 600;
 		text-align: left;
 		white-space: nowrap;
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.sticky-header thead th {
@@ -185,26 +185,26 @@
 	.size-sm th,
 	.size-sm td {
 		padding: var(--dss-space-2, 8px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		height: 36px;
 	}
 	.size-md th,
 	.size-md td {
 		padding: var(--dss-space-4, 16px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		height: 44px;
 	}
 	.size-lg th,
 	.size-lg td {
 		padding: var(--dss-space-6, 24px) var(--dss-space-4, 16px);
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		height: 52px;
 	}
 
 	/* Body */
 	tbody td {
 		color: var(--ssk-colors-text-700, #374151);
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 
 	/* Alignment */
@@ -236,7 +236,7 @@
 	.checkbox-col input[type="checkbox"] {
 		width: 16px;
 		height: 16px;
-		accent-color: var(--ssk-colors-primary-500, #32a9ff);
+		accent-color: var(--primary, #32a9ff);
 		cursor: pointer;
 	}
 
@@ -245,7 +245,7 @@
 		text-align: center;
 		padding: var(--dss-space-24, 96px) var(--dss-space-4, 16px);
 		color: var(--ssk-colors-text-400, #9ca3af);
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 	}
 
 	/* Skeleton */
@@ -255,8 +255,8 @@
 	.skeleton-bone {
 		display: inline-block;
 		height: 14px;
-		border-radius: var(--dss-radius-xs, 4px);
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--radius-xs, 4px);
+		background: var(--border, #e5e7eb);
 		animation: dss-table-pulse 1.5s ease-in-out infinite;
 	}
 

--- a/src/lib/svelte/feedback/Alert.svelte
+++ b/src/lib/svelte/feedback/Alert.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let variant: 'info' | 'success' | 'warning' | 'error' = 'info';
+	export let title: string | undefined = undefined;
+	export let dismissible: boolean = false;
+
+	const dispatch = createEventDispatcher<{ dismiss: void }>();
+
+	let visible = true;
+
+	function handleDismiss() {
+		visible = false;
+		dispatch('dismiss');
+	}
+
+	const variantIcons: Record<string, string> = {
+		info: '\u2139\uFE0F',
+		success: '\u2705',
+		warning: '\u26A0\uFE0F',
+		error: '\u274C'
+	};
+</script>
+
+{#if visible}
+	<div class="dss-alert variant-{variant}" role="alert">
+		<div class="alert-icon">
+			<slot name="icon">
+				<span class="alert-icon-default">{variantIcons[variant]}</span>
+			</slot>
+		</div>
+		<div class="alert-body">
+			{#if title}
+				<div class="alert-title">{title}</div>
+			{/if}
+			<div class="alert-message">
+				<slot />
+			</div>
+			<slot name="action" />
+		</div>
+		{#if dismissible}
+			<button class="alert-close" on:click={handleDismiss} type="button" aria-label="Dismiss">
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<path d="M4 4l8 8M12 4l-8 8" />
+				</svg>
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.dss-alert {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--dss-space-12, 12px);
+		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
+		border-radius: var(--dss-radius-md, 8px);
+		border-left: 4px solid;
+		width: 100%;
+		box-sizing: border-box;
+		font-family: 'Inter', sans-serif;
+		animation: dss-alert-in 0.2s ease-out;
+	}
+
+	/* Info */
+	.variant-info {
+		background: #eff6ff;
+		border-left-color: var(--ssk-colors-primary-500, #3b82f6);
+		color: var(--ssk-colors-primary-500, #3b82f6);
+	}
+	.variant-info .alert-title { color: var(--ssk-colors-primary-500, #3b82f6); }
+	.variant-info .alert-message { color: var(--ssk-colors-text-700, #374151); }
+
+	/* Success */
+	.variant-success {
+		background: #ecfdf5;
+		border-left-color: #10b981;
+		color: #059669;
+	}
+	.variant-success .alert-title { color: #059669; }
+	.variant-success .alert-message { color: var(--ssk-colors-text-700, #374151); }
+
+	/* Warning */
+	.variant-warning {
+		background: #fffbeb;
+		border-left-color: #f59e0b;
+		color: #d97706;
+	}
+	.variant-warning .alert-title { color: #d97706; }
+	.variant-warning .alert-message { color: var(--ssk-colors-text-700, #374151); }
+
+	/* Error */
+	.variant-error {
+		background: #fef2f2;
+		border-left-color: #ef4444;
+		color: #dc2626;
+	}
+	.variant-error .alert-title { color: #dc2626; }
+	.variant-error .alert-message { color: var(--ssk-colors-text-700, #374151); }
+
+	.alert-icon {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		margin-top: 1px;
+	}
+
+	.alert-icon-default {
+		font-size: 16px;
+		line-height: 1;
+	}
+
+	.alert-body {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.alert-title {
+		font-size: 14px;
+		font-weight: 600;
+		line-height: 1.4;
+		margin-bottom: var(--dss-space-4, 4px);
+	}
+
+	.alert-message {
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.alert-close {
+		flex-shrink: 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: var(--dss-space-4, 4px);
+		color: inherit;
+		opacity: 0.5;
+		border-radius: var(--dss-radius-sm, 4px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: opacity 0.15s;
+	}
+
+	.alert-close:hover {
+		opacity: 1;
+	}
+
+	@keyframes dss-alert-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+</style>

--- a/src/lib/svelte/feedback/Alert.svelte
+++ b/src/lib/svelte/feedback/Alert.svelte
@@ -54,21 +54,21 @@
 		align-items: flex-start;
 		gap: var(--dss-space-12, 12px);
 		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		border-left: 4px solid;
 		width: 100%;
 		box-sizing: border-box;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		animation: dss-alert-in 0.2s ease-out;
 	}
 
 	/* Info */
 	.variant-info {
 		background: #eff6ff;
-		border-left-color: var(--ssk-colors-primary-500, #3b82f6);
-		color: var(--ssk-colors-primary-500, #3b82f6);
+		border-left-color: var(--primary, #3b82f6);
+		color: var(--primary, #3b82f6);
 	}
-	.variant-info .alert-title { color: var(--ssk-colors-primary-500, #3b82f6); }
+	.variant-info .alert-title { color: var(--primary, #3b82f6); }
 	.variant-info .alert-message { color: var(--ssk-colors-text-700, #374151); }
 
 	/* Success */
@@ -135,7 +135,7 @@
 		padding: var(--dss-space-4, 4px);
 		color: inherit;
 		opacity: 0.5;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/src/lib/svelte/feedback/NotificationCenter.svelte
+++ b/src/lib/svelte/feedback/NotificationCenter.svelte
@@ -17,7 +17,7 @@
 	$: unreadCount = items.filter((i) => !i.read).length;
 
 	const typeColors: Record<string, string> = {
-		info: 'var(--ssk-colors-primary-500, #3b82f6)',
+		info: 'var(--primary, #3b82f6)',
 		success: '#10b981',
 		warning: '#f59e0b',
 		error: '#ef4444'
@@ -105,8 +105,8 @@
 		width: 100%;
 		max-width: 400px;
 		background: var(--dss-bg-primary, #ffffff);
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-lg, 12px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 		overflow: hidden;
 	}
@@ -116,16 +116,16 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: var(--dss-space-16, 16px);
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.nc-title {
 		display: flex;
 		align-items: center;
 		gap: var(--dss-space-8, 8px);
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 	}
 
 	.nc-badge {
@@ -135,8 +135,8 @@
 		min-width: 20px;
 		height: 20px;
 		padding: 0 6px;
-		border-radius: var(--dss-radius-full, 9999px);
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		border-radius: var(--radius-full, 9999px);
+		background: var(--primary, #32a9ff);
 		color: white;
 		font-size: 11px;
 		font-weight: 600;
@@ -151,8 +151,8 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		font-size: var(--text-caption, 12px);
+		color: var(--primary, #32a9ff);
 		font-family: inherit;
 		padding: 0;
 	}
@@ -175,7 +175,7 @@
 		gap: var(--dss-space-8, 8px);
 		padding: var(--dss-space-32, 32px);
 		color: var(--ssk-colors-text-400, #9ca3af);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 	}
 
 	.nc-item {
@@ -212,19 +212,19 @@
 	}
 
 	.nc-item-title {
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		font-weight: 500;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 	}
 
 	.nc-item-message {
-		font-size: var(--dss-font-sm, 13px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-sm, 13px);
+		color: var(--muted-foreground, #6b7280);
 		margin-top: 2px;
 	}
 
 	.nc-item-time {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 		margin-top: 4px;
 	}
@@ -234,7 +234,7 @@
 		border: none;
 		cursor: pointer;
 		padding: 4px;
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 		flex-shrink: 0;
 		opacity: 0;
@@ -246,7 +246,7 @@
 	}
 
 	.nc-dismiss:hover {
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 		color: var(--ssk-colors-text-700, #374151);
 	}
 </style>

--- a/src/lib/svelte/feedback/NotificationCenter.svelte
+++ b/src/lib/svelte/feedback/NotificationCenter.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let items: NotificationItem[] = [];
+
+	interface NotificationItem {
+		id: string;
+		type: 'info' | 'success' | 'warning' | 'error';
+		title: string;
+		message?: string;
+		time: string;
+		read: boolean;
+	}
+
+	const dispatch = createEventDispatcher();
+
+	$: unreadCount = items.filter((i) => !i.read).length;
+
+	const typeColors: Record<string, string> = {
+		info: 'var(--ssk-colors-primary-500, #3b82f6)',
+		success: '#10b981',
+		warning: '#f59e0b',
+		error: '#ef4444'
+	};
+
+	function markRead(id: string) {
+		dispatch('markRead', id);
+	}
+
+	function markAllRead() {
+		dispatch('markAllRead');
+	}
+
+	function dismiss(id: string) {
+		dispatch('dismiss', id);
+	}
+
+	function clearAll() {
+		dispatch('clearAll');
+	}
+</script>
+
+<div class="dss-notification-center">
+	<div class="nc-header">
+		<div class="nc-title">
+			<span>Notifications</span>
+			{#if unreadCount > 0}
+				<span class="nc-badge">{unreadCount}</span>
+			{/if}
+		</div>
+		<div class="nc-actions">
+			{#if unreadCount > 0}
+				<button class="nc-link" on:click={markAllRead} type="button">Mark all read</button>
+			{/if}
+			{#if items.length > 0}
+				<button class="nc-link nc-link-danger" on:click={clearAll} type="button">Clear all</button>
+			{/if}
+		</div>
+	</div>
+
+	<div class="nc-list">
+		{#if items.length === 0}
+			<div class="nc-empty">
+				<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+					<path d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+				<span>No notifications</span>
+			</div>
+		{:else}
+			{#each items as item (item.id)}
+				<div
+					class="nc-item"
+					class:unread={!item.read}
+					on:click={() => markRead(item.id)}
+					on:keypress={() => markRead(item.id)}
+					role="button"
+					tabindex={0}
+				>
+					<div class="nc-dot" style:background={!item.read ? typeColors[item.type] : 'transparent'}></div>
+					<div class="nc-content">
+						<div class="nc-item-title">{item.title}</div>
+						{#if item.message}
+							<div class="nc-item-message">{item.message}</div>
+						{/if}
+						<div class="nc-item-time">{item.time}</div>
+					</div>
+					<button
+						class="nc-dismiss"
+						on:click|stopPropagation={() => dismiss(item.id)}
+						type="button"
+						aria-label="Dismiss"
+					>
+						<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+							<path d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+						</svg>
+					</button>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.dss-notification-center {
+		width: 100%;
+		max-width: 400px;
+		background: var(--dss-bg-primary, #ffffff);
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		overflow: hidden;
+	}
+
+	.nc-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--dss-space-16, 16px);
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.nc-title {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		font-size: var(--dss-font-body, 14px);
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+	}
+
+	.nc-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 20px;
+		height: 20px;
+		padding: 0 6px;
+		border-radius: var(--dss-radius-full, 9999px);
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		font-size: 11px;
+		font-weight: 600;
+	}
+
+	.nc-actions {
+		display: flex;
+		gap: var(--dss-space-12, 12px);
+	}
+
+	.nc-link {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		font-family: inherit;
+		padding: 0;
+	}
+	.nc-link:hover {
+		text-decoration: underline;
+	}
+	.nc-link-danger {
+		color: #ef4444;
+	}
+
+	.nc-list {
+		max-height: 400px;
+		overflow-y: auto;
+	}
+
+	.nc-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		padding: var(--dss-space-32, 32px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		font-size: var(--dss-font-sm, 13px);
+	}
+
+	.nc-item {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--dss-space-12, 12px);
+		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
+		cursor: pointer;
+		transition: background 0.1s;
+	}
+
+	.nc-item:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	.nc-item.unread {
+		background: var(--ssk-colors-primary-50, #f0f9ff);
+	}
+	.nc-item.unread:hover {
+		background: var(--ssk-colors-primary-100, #d9f2ff);
+	}
+
+	.nc-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		margin-top: 6px;
+	}
+
+	.nc-content {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.nc-item-title {
+		font-size: var(--dss-font-body, 14px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-900, #111827);
+	}
+
+	.nc-item-message {
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		margin-top: 2px;
+	}
+
+	.nc-item-time {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		margin-top: 4px;
+	}
+
+	.nc-dismiss {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 4px;
+		border-radius: var(--dss-radius-sm, 6px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+		opacity: 0;
+		transition: opacity 0.1s;
+	}
+
+	.nc-item:hover .nc-dismiss {
+		opacity: 1;
+	}
+
+	.nc-dismiss:hover {
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		color: var(--ssk-colors-text-700, #374151);
+	}
+</style>

--- a/src/lib/svelte/form/Checkbox.svelte
+++ b/src/lib/svelte/form/Checkbox.svelte
@@ -89,7 +89,7 @@
 		align-items: flex-start;
 		gap: var(--dss-space-2, 8px);
 		cursor: pointer;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		user-select: none;
 	}
 	.dss-checkbox.disabled {
@@ -115,7 +115,7 @@
 		align-items: center;
 		justify-content: center;
 		border: 2px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-xs, 4px);
+		border-radius: var(--radius-xs, 4px);
 		background: white;
 		flex-shrink: 0;
 		transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
@@ -124,7 +124,7 @@
 	.checkbox-box:focus-visible {
 		outline: none;
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	.dss-checkbox:not(.disabled):hover .checkbox-box:not(.checked):not(.indeterminate) {
@@ -133,8 +133,8 @@
 
 	.checkbox-box.checked,
 	.checkbox-box.indeterminate {
-		background: var(--ssk-colors-primary-500, #32a9ff);
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 	.dss-checkbox:not(.disabled):hover .checkbox-box.checked,
 	.dss-checkbox:not(.disabled):hover .checkbox-box.indeterminate {
@@ -162,16 +162,16 @@
 	.size-lg .checkbox-label { font-size: 15px; }
 
 	.checkbox-description {
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-caption, 12px);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.4;
 	}
 
 	/* Error */
 	.dss-checkbox-error {
 		margin: var(--dss-space-1, 4px) 0 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-danger-500, #ef4444);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 </style>

--- a/src/lib/svelte/form/Checkbox.svelte
+++ b/src/lib/svelte/form/Checkbox.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let checked: boolean = false;
+	export let indeterminate: boolean = false;
+	export let label: string = '';
+	export let description: string = '';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let disabled: boolean = false;
+	export let error: string = '';
+
+	const dispatch = createEventDispatcher<{ change: { checked: boolean } }>();
+
+	const sizeMap = { sm: 16, md: 18, lg: 20 };
+	$: boxSize = sizeMap[size];
+
+	function handleChange() {
+		if (disabled) return;
+		checked = !checked;
+		indeterminate = false;
+		dispatch('change', { checked });
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === ' ' || e.key === 'Enter') {
+			e.preventDefault();
+			handleChange();
+		}
+	}
+</script>
+
+<label
+	class="dss-checkbox size-{size}"
+	class:disabled
+	class:has-error={!!error}
+>
+	<span
+		class="checkbox-box"
+		class:checked
+		class:indeterminate
+		role="checkbox"
+		aria-checked={indeterminate ? 'mixed' : checked}
+		aria-disabled={disabled}
+		tabindex={disabled ? -1 : 0}
+		style="width: {boxSize}px; height: {boxSize}px;"
+		on:click={handleChange}
+		on:keydown={handleKeydown}
+	>
+		{#if checked}
+			<svg viewBox="0 0 16 16" fill="none" width={boxSize - 4} height={boxSize - 4}>
+				<path d="M3.5 8.5L6.5 11.5L12.5 4.5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+			</svg>
+		{:else if indeterminate}
+			<svg viewBox="0 0 16 16" fill="none" width={boxSize - 4} height={boxSize - 4}>
+				<path d="M4 8H12" stroke="white" stroke-width="2" stroke-linecap="round" />
+			</svg>
+		{/if}
+	</span>
+
+	{#if label || description}
+		<span class="checkbox-content">
+			{#if label}
+				<span class="checkbox-label">{label}</span>
+			{/if}
+			{#if description}
+				<span class="checkbox-description">{description}</span>
+			{/if}
+		</span>
+	{/if}
+
+	<input
+		type="checkbox"
+		bind:checked
+		{disabled}
+		{indeterminate}
+		class="sr-only"
+		tabindex="-1"
+		aria-hidden="true"
+	/>
+</label>
+
+{#if error}
+	<p class="dss-checkbox-error">{error}</p>
+{/if}
+
+<style>
+	.dss-checkbox {
+		display: inline-flex;
+		align-items: flex-start;
+		gap: var(--dss-space-2, 8px);
+		cursor: pointer;
+		font-family: 'Inter', sans-serif;
+		user-select: none;
+	}
+	.dss-checkbox.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	/* Box */
+	.checkbox-box {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: 2px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-xs, 4px);
+		background: white;
+		flex-shrink: 0;
+		transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+		margin-top: 1px;
+	}
+	.checkbox-box:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.dss-checkbox:not(.disabled):hover .checkbox-box:not(.checked):not(.indeterminate) {
+		border-color: var(--ssk-colors-primary-400, #60bfff);
+	}
+
+	.checkbox-box.checked,
+	.checkbox-box.indeterminate {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.dss-checkbox:not(.disabled):hover .checkbox-box.checked,
+	.dss-checkbox:not(.disabled):hover .checkbox-box.indeterminate {
+		background: var(--ssk-colors-primary-600, #1b8bf5);
+		border-color: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	.has-error .checkbox-box {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+	}
+
+	/* Content */
+	.checkbox-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.checkbox-label {
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.size-sm .checkbox-label { font-size: 13px; }
+	.size-md .checkbox-label { font-size: 14px; }
+	.size-lg .checkbox-label { font-size: 15px; }
+
+	.checkbox-description {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.4;
+	}
+
+	/* Error */
+	.dss-checkbox-error {
+		margin: var(--dss-space-1, 4px) 0 0;
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-danger-500, #ef4444);
+		font-family: 'Inter', sans-serif;
+	}
+</style>

--- a/src/lib/svelte/form/CheckboxGroup.svelte
+++ b/src/lib/svelte/form/CheckboxGroup.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	export let label: string = '';
+	export let direction: 'horizontal' | 'vertical' = 'vertical';
+</script>
+
+<fieldset class="dss-checkbox-group" role="group" aria-label={label || undefined}>
+	{#if label}
+		<legend class="dss-checkbox-group-label">{label}</legend>
+	{/if}
+
+	<div class="dss-checkbox-group-items direction-{direction}">
+		<slot />
+	</div>
+</fieldset>
+
+<style>
+	.dss-checkbox-group {
+		border: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-2, 8px);
+		font-family: 'Inter', sans-serif;
+	}
+
+	.dss-checkbox-group-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		padding: 0;
+		line-height: 1.4;
+	}
+
+	.dss-checkbox-group-items {
+		display: flex;
+	}
+	.direction-vertical {
+		flex-direction: column;
+		gap: var(--dss-space-4, 12px);
+	}
+	.direction-horizontal {
+		flex-direction: row;
+		flex-wrap: wrap;
+		gap: var(--dss-space-6, 16px);
+	}
+</style>

--- a/src/lib/svelte/form/CheckboxGroup.svelte
+++ b/src/lib/svelte/form/CheckboxGroup.svelte
@@ -21,11 +21,11 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--dss-space-2, 8px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.dss-checkbox-group-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		padding: 0;

--- a/src/lib/svelte/form/ColorPicker.svelte
+++ b/src/lib/svelte/form/ColorPicker.svelte
@@ -139,12 +139,12 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-4, 4px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		position: relative;
 	}
 
 	.dss-colorpicker-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
@@ -154,7 +154,7 @@
 		align-items: center;
 		gap: var(--dss-space-8, 8px);
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		background: white;
 		cursor: pointer;
 		font-family: inherit;
@@ -162,7 +162,7 @@
 		padding: 0 var(--dss-space-12, 12px);
 	}
 	.dss-colorpicker-trigger:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 		outline: none;
 	}
@@ -174,7 +174,7 @@
 	.color-swatch {
 		width: 20px;
 		height: 20px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		flex-shrink: 0;
 	}
@@ -198,8 +198,8 @@
 		margin-top: 4px;
 		z-index: 50;
 		background: white;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-lg, 12px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 		padding: var(--dss-space-12, 12px);
 		min-width: 220px;
@@ -217,7 +217,7 @@
 	.preset-swatch {
 		width: 24px;
 		height: 24px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		cursor: pointer;
 		padding: 0;
@@ -231,7 +231,7 @@
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 	}
 	.preset-swatch.selected {
-		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--primary, #32a9ff);
 	}
 
 	.input-row {
@@ -242,7 +242,7 @@
 	.input-swatch {
 		width: 28px;
 		height: 28px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		flex-shrink: 0;
 	}
@@ -250,15 +250,15 @@
 		flex: 1;
 		height: 32px;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		padding: 0 8px;
 		font-size: 13px;
 		font-family: monospace;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		outline: none;
 	}
 	.hex-input:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	.formats {
@@ -267,8 +267,8 @@
 		gap: 2px;
 	}
 	.format-label {
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-caption, 12px);
+		color: var(--muted-foreground, #6b7280);
 		font-family: monospace;
 	}
 </style>

--- a/src/lib/svelte/form/ColorPicker.svelte
+++ b/src/lib/svelte/form/ColorPicker.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+
+	export let value: string = '#000000';
+	export let label: string = '';
+	export let presets: string[] = [
+		'#ef4444', '#f97316', '#f59e0b', '#10b981', '#06b6d4',
+		'#3b82f6', '#6366f1', '#8b5cf6', '#ec4899', '#f43f5e',
+		'#000000', '#374151', '#6b7280', '#9ca3af', '#d1d5db', '#ffffff'
+	];
+	export let showInput: boolean = true;
+	export let showFormats: boolean = false;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+
+	const dispatch = createEventDispatcher<{
+		change: string;
+	}>();
+
+	let open = false;
+	let wrapperEl: HTMLDivElement;
+	let inputValue: string = value;
+
+	$: inputValue = value;
+
+	function selectColor(color: string) {
+		value = color;
+		inputValue = color;
+		dispatch('change', color);
+	}
+
+	function handleInputChange() {
+		const hex = inputValue.trim();
+		if (/^#[0-9a-fA-F]{6}$/.test(hex) || /^#[0-9a-fA-F]{3}$/.test(hex)) {
+			value = hex;
+			dispatch('change', hex);
+		}
+	}
+
+	function handleInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') handleInputChange();
+	}
+
+	function hexToRgb(hex: string): string {
+		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+		if (!result) return '';
+		return `rgb(${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)})`;
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		if (open && wrapperEl && !wrapperEl.contains(e.target as Node)) {
+			open = false;
+		}
+	}
+
+	onMount(() => document.addEventListener('mousedown', handleClickOutside));
+	onDestroy(() => document.removeEventListener('mousedown', handleClickOutside));
+</script>
+
+<div class="dss-colorpicker" bind:this={wrapperEl}>
+	{#if label}
+		<span class="dss-colorpicker-label">{label}</span>
+	{/if}
+
+	<button
+		type="button"
+		class="dss-colorpicker-trigger size-{size}"
+		on:click={() => (open = !open)}
+	>
+		<span class="color-swatch" style="background: {value}"></span>
+		{#if showInput}
+			<span class="color-value">{value}</span>
+		{/if}
+		<svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<polyline points="6 9 12 15 18 9" />
+		</svg>
+	</button>
+
+	{#if open}
+		<div class="dss-colorpicker-dropdown">
+			{#if presets.length > 0}
+				<div class="preset-grid">
+					{#each presets as color}
+						<button
+							type="button"
+							class="preset-swatch"
+							class:selected={value === color}
+							style="background: {color}"
+							title={color}
+							on:click={() => selectColor(color)}
+						>
+							{#if value === color}
+								<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={isLightColor(color) ? '#374151' : 'white'} stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+									<polyline points="20 6 9 17 4 12" />
+								</svg>
+							{/if}
+						</button>
+					{/each}
+				</div>
+			{/if}
+
+			{#if showInput}
+				<div class="input-row">
+					<span class="input-swatch" style="background: {value}"></span>
+					<input
+						type="text"
+						class="hex-input"
+						bind:value={inputValue}
+						on:blur={handleInputChange}
+						on:keydown={handleInputKeydown}
+						placeholder="#000000"
+						maxlength="7"
+					/>
+				</div>
+			{/if}
+
+			{#if showFormats}
+				<div class="formats">
+					<span class="format-label">HEX: {value}</span>
+					<span class="format-label">RGB: {hexToRgb(value)}</span>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<script context="module" lang="ts">
+	function isLightColor(hex: string): boolean {
+		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+		if (!result) return false;
+		const r = parseInt(result[1], 16);
+		const g = parseInt(result[2], 16);
+		const b = parseInt(result[3], 16);
+		return (r * 299 + g * 587 + b * 114) / 1000 > 186;
+	}
+</script>
+
+<style>
+	.dss-colorpicker {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+		font-family: 'Inter', sans-serif;
+		position: relative;
+	}
+
+	.dss-colorpicker-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.dss-colorpicker-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		background: white;
+		cursor: pointer;
+		font-family: inherit;
+		transition: border-color 0.15s, box-shadow 0.15s;
+		padding: 0 var(--dss-space-12, 12px);
+	}
+	.dss-colorpicker-trigger:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+		outline: none;
+	}
+
+	.size-sm { height: 32px; font-size: 13px; }
+	.size-md { height: 36px; font-size: 14px; }
+	.size-lg { height: 40px; font-size: 15px; }
+
+	.color-swatch {
+		width: 20px;
+		height: 20px;
+		border-radius: var(--dss-radius-sm, 4px);
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		flex-shrink: 0;
+	}
+
+	.color-value {
+		color: var(--ssk-colors-text-700, #374151);
+		font-family: monospace;
+		font-size: inherit;
+	}
+
+	.chevron {
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+	}
+
+	/* Dropdown */
+	.dss-colorpicker-dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		margin-top: 4px;
+		z-index: 50;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		padding: var(--dss-space-12, 12px);
+		min-width: 220px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-12, 12px);
+	}
+
+	.preset-grid {
+		display: grid;
+		grid-template-columns: repeat(8, 1fr);
+		gap: 6px;
+	}
+
+	.preset-swatch {
+		width: 24px;
+		height: 24px;
+		border-radius: var(--dss-radius-sm, 4px);
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		cursor: pointer;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: transform 0.1s, box-shadow 0.1s;
+	}
+	.preset-swatch:hover {
+		transform: scale(1.15);
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+	}
+	.preset-swatch.selected {
+		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.input-row {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+	}
+	.input-swatch {
+		width: 28px;
+		height: 28px;
+		border-radius: var(--dss-radius-sm, 4px);
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		flex-shrink: 0;
+	}
+	.hex-input {
+		flex: 1;
+		height: 32px;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-sm, 4px);
+		padding: 0 8px;
+		font-size: 13px;
+		font-family: monospace;
+		color: var(--ssk-colors-text-900, #111827);
+		outline: none;
+	}
+	.hex-input:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.formats {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+	.format-label {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-family: monospace;
+	}
+</style>

--- a/src/lib/svelte/form/DatePicker.svelte
+++ b/src/lib/svelte/form/DatePicker.svelte
@@ -1,0 +1,546 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+
+	export let value: Date | null = null;
+	export let rangeValue: { start: Date | null; end: Date | null } = { start: null, end: null };
+	export let mode: 'single' | 'range' = 'single';
+	export let label: string = '';
+	export let placeholder: string = '';
+	export let helperText: string = '';
+	export let errorMessage: string = '';
+	export let successMessage: string = '';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let variant: 'default' | 'outlined' | 'filled' = 'default';
+	export let state: 'default' | 'error' | 'success' = 'default';
+	export let disabled: boolean = false;
+	export let required: boolean = false;
+	export let clearable: boolean = true;
+	export let showTime: boolean = false;
+	export let minDate: Date | undefined = undefined;
+	export let maxDate: Date | undefined = undefined;
+	export let showToday: boolean = true;
+	export let fullWidth: boolean = false;
+
+	const dispatch = createEventDispatcher<{
+		change: Date | null;
+		rangeChange: { start: Date | null; end: Date | null };
+	}>();
+
+	let open = false;
+	let wrapperEl: HTMLDivElement;
+	let viewYear: number;
+	let viewMonth: number;
+	let hours = 0;
+	let minutes = 0;
+	let rangeSelecting: 'start' | 'end' = 'start';
+
+	const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+	const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+	$: computedState = errorMessage ? 'error' : successMessage ? 'success' : state;
+	$: message = errorMessage || successMessage || helperText;
+	$: today = new Date();
+	$: {
+		const ref = mode === 'single' && value ? value : today;
+		if (viewYear === undefined) viewYear = ref.getFullYear();
+		if (viewMonth === undefined) viewMonth = ref.getMonth();
+	}
+
+	$: daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+	$: firstDayOfWeek = new Date(viewYear, viewMonth, 1).getDay();
+	$: calendarDays = buildCalendarDays(viewYear, viewMonth, daysInMonth, firstDayOfWeek);
+
+	$: displayValue = formatDisplay(mode, value, rangeValue, showTime);
+
+	function buildCalendarDays(_y: number, _m: number, dim: number, fdow: number): (number | null)[] {
+		const days: (number | null)[] = [];
+		for (let i = 0; i < fdow; i++) days.push(null);
+		for (let d = 1; d <= dim; d++) days.push(d);
+		return days;
+	}
+
+	function formatDisplay(_mode: string, _val: Date | null, _range: { start: Date | null; end: Date | null }, _showTime: boolean): string {
+		if (_mode === 'single' && _val) {
+			const s = formatDate(_val);
+			return _showTime ? `${s} ${pad(_val.getHours())}:${pad(_val.getMinutes())}` : s;
+		}
+		if (_mode === 'range') {
+			const s = _range.start ? formatDate(_range.start) : '';
+			const e = _range.end ? formatDate(_range.end) : '';
+			if (s && e) return `${s} - ${e}`;
+			if (s) return `${s} - ...`;
+			return '';
+		}
+		return '';
+	}
+
+	function formatDate(d: Date): string {
+		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+	}
+
+	function pad(n: number): string {
+		return n < 10 ? `0${n}` : `${n}`;
+	}
+
+	function isSameDay(a: Date, b: Date): boolean {
+		return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+	}
+
+	function isToday(day: number): boolean {
+		return today.getFullYear() === viewYear && today.getMonth() === viewMonth && today.getDate() === day;
+	}
+
+	function isSelected(day: number): boolean {
+		if (mode === 'single' && value) {
+			return value.getFullYear() === viewYear && value.getMonth() === viewMonth && value.getDate() === day;
+		}
+		if (mode === 'range') {
+			const d = new Date(viewYear, viewMonth, day);
+			if (rangeValue.start && isSameDay(d, rangeValue.start)) return true;
+			if (rangeValue.end && isSameDay(d, rangeValue.end)) return true;
+		}
+		return false;
+	}
+
+	function isInRange(day: number): boolean {
+		if (mode !== 'range' || !rangeValue.start || !rangeValue.end) return false;
+		const d = new Date(viewYear, viewMonth, day);
+		return d > rangeValue.start && d < rangeValue.end;
+	}
+
+	function isDayDisabled(day: number): boolean {
+		const d = new Date(viewYear, viewMonth, day);
+		if (minDate && d < new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate())) return true;
+		if (maxDate && d > new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate())) return true;
+		return false;
+	}
+
+	function selectDay(day: number | null) {
+		if (day === null || isDayDisabled(day)) return;
+		if (mode === 'single') {
+			const d = new Date(viewYear, viewMonth, day, hours, minutes);
+			value = d;
+			dispatch('change', d);
+			if (!showTime) open = false;
+		} else {
+			if (rangeSelecting === 'start') {
+				rangeValue = { start: new Date(viewYear, viewMonth, day), end: null };
+				rangeSelecting = 'end';
+			} else {
+				const endDate = new Date(viewYear, viewMonth, day);
+				if (rangeValue.start && endDate < rangeValue.start) {
+					rangeValue = { start: endDate, end: rangeValue.start };
+				} else {
+					rangeValue = { ...rangeValue, end: endDate };
+				}
+				rangeSelecting = 'start';
+				dispatch('rangeChange', rangeValue);
+				open = false;
+			}
+		}
+	}
+
+	function prevMonth() {
+		if (viewMonth === 0) { viewMonth = 11; viewYear--; }
+		else viewMonth--;
+	}
+
+	function nextMonth() {
+		if (viewMonth === 11) { viewMonth = 0; viewYear++; }
+		else viewMonth++;
+	}
+
+	function goToday() {
+		viewYear = today.getFullYear();
+		viewMonth = today.getMonth();
+	}
+
+	function handleClear(e: MouseEvent) {
+		e.stopPropagation();
+		if (mode === 'single') {
+			value = null;
+			dispatch('change', null);
+		} else {
+			rangeValue = { start: null, end: null };
+			rangeSelecting = 'start';
+			dispatch('rangeChange', rangeValue);
+		}
+	}
+
+	function handleTimeChange() {
+		if (value) {
+			value = new Date(value.getFullYear(), value.getMonth(), value.getDate(), hours, minutes);
+			dispatch('change', value);
+		}
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		if (open && wrapperEl && !wrapperEl.contains(e.target as Node)) {
+			open = false;
+		}
+	}
+
+	onMount(() => {
+		document.addEventListener('mousedown', handleClickOutside);
+	});
+
+	onDestroy(() => {
+		document.removeEventListener('mousedown', handleClickOutside);
+	});
+</script>
+
+<div class="dss-datepicker-wrapper" class:full-width={fullWidth} bind:this={wrapperEl}>
+	{#if label}
+		<label class="dss-datepicker-label">
+			{label}
+			{#if required}
+				<span class="required-mark" aria-hidden="true">*</span>
+			{/if}
+		</label>
+	{/if}
+
+	<button
+		type="button"
+		class="dss-datepicker-input size-{size} variant-{variant} state-{computedState}"
+		class:disabled
+		class:open
+		{disabled}
+		on:click={() => { if (!disabled) open = !open; }}
+	>
+		<svg class="calendar-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+		</svg>
+		<span class="display-value" class:placeholder={!displayValue}>
+			{displayValue || placeholder || (mode === 'range' ? 'Select date range' : 'Select date')}
+		</span>
+		{#if clearable && displayValue && !disabled}
+			<button type="button" class="clear-btn" tabindex="-1" aria-label="Clear" on:click={handleClear}>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+				</svg>
+			</button>
+		{/if}
+	</button>
+
+	{#if open}
+		<div class="dss-datepicker-dropdown">
+			<div class="calendar-header">
+				<button type="button" class="nav-btn" on:click={prevMonth} aria-label="Previous month">
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+				</button>
+				<span class="month-year">{MONTHS[viewMonth]} {viewYear}</span>
+				<button type="button" class="nav-btn" on:click={nextMonth} aria-label="Next month">
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+				</button>
+			</div>
+
+			<div class="calendar-grid">
+				{#each DAYS as dayName}
+					<span class="day-name">{dayName}</span>
+				{/each}
+				{#each calendarDays as day}
+					{#if day === null}
+						<span class="day-cell empty"></span>
+					{:else}
+						<button
+							type="button"
+							class="day-cell"
+							class:today={isToday(day)}
+							class:selected={isSelected(day)}
+							class:in-range={isInRange(day)}
+							class:disabled={isDayDisabled(day)}
+							disabled={isDayDisabled(day)}
+							on:click={() => selectDay(day)}
+						>
+							{day}
+						</button>
+					{/if}
+				{/each}
+			</div>
+
+			{#if showTime && mode === 'single'}
+				<div class="time-row">
+					<input type="number" class="time-input" min="0" max="23" bind:value={hours} on:change={handleTimeChange} />
+					<span class="time-sep">:</span>
+					<input type="number" class="time-input" min="0" max="59" bind:value={minutes} on:change={handleTimeChange} />
+				</div>
+			{/if}
+
+			{#if showToday}
+				<div class="calendar-footer">
+					<button type="button" class="today-btn" on:click={goToday}>Today</button>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	{#if message}
+		<p class="dss-datepicker-message state-{computedState}">{message}</p>
+	{/if}
+</div>
+
+<style>
+	.dss-datepicker-wrapper {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+		font-family: 'Inter', sans-serif;
+		position: relative;
+	}
+	.full-width { width: 100%; }
+
+	.dss-datepicker-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.required-mark {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		margin-left: 2px;
+	}
+
+	.dss-datepicker-input {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		border-radius: var(--dss-radius-md, 8px);
+		cursor: pointer;
+		transition: border-color 0.15s, box-shadow 0.15s;
+		padding: 0 var(--dss-space-12, 12px);
+		width: 100%;
+		text-align: left;
+		font-family: inherit;
+		background: none;
+	}
+
+	.size-sm { height: 32px; font-size: 13px; }
+	.size-md { height: 36px; font-size: 14px; }
+	.size-lg { height: 40px; font-size: 15px; }
+
+	.variant-default {
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-default.open, .variant-default:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+	.variant-outlined {
+		background: transparent;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outlined.open, .variant-outlined:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+	.variant-filled {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border: 1px solid transparent;
+	}
+	.variant-filled.open, .variant-filled:focus {
+		background: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.state-error { border-color: var(--ssk-colors-danger-500, #ef4444) !important; }
+	.state-error.open { box-shadow: 0 0 0 2px var(--ssk-colors-danger-50, #fef2f2) !important; }
+	.state-success { border-color: var(--ssk-colors-success-500, #10b981) !important; }
+	.state-success.open { box-shadow: 0 0 0 2px var(--ssk-colors-success-50, #ecfdf5) !important; }
+
+	.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		pointer-events: none;
+	}
+
+	.calendar-icon {
+		flex-shrink: 0;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.display-value {
+		flex: 1;
+		color: var(--ssk-colors-text-900, #111827);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.display-value.placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.clear-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 2px;
+		border-radius: var(--dss-radius-sm, 4px);
+		transition: color 0.15s;
+	}
+	.clear-btn:hover {
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	/* Dropdown */
+	.dss-datepicker-dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		margin-top: 4px;
+		z-index: 50;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		padding: var(--dss-space-12, 12px);
+		min-width: 280px;
+	}
+
+	.calendar-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: var(--dss-space-8, 8px);
+	}
+	.month-year {
+		font-size: var(--dss-font-body, 14px);
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+	}
+	.nav-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-500, #6b7280);
+		padding: 4px;
+		border-radius: var(--dss-radius-sm, 4px);
+		transition: background 0.15s, color 0.15s;
+	}
+	.nav-btn:hover {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-900, #111827);
+	}
+
+	.calendar-grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		gap: 2px;
+		text-align: center;
+	}
+	.day-name {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 4px 0;
+		text-transform: uppercase;
+	}
+	.day-cell {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 34px;
+		height: 34px;
+		border-radius: var(--dss-radius-md, 8px);
+		font-size: 13px;
+		color: var(--ssk-colors-text-700, #374151);
+		background: none;
+		border: none;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+		margin: 0 auto;
+	}
+	.day-cell.empty {
+		cursor: default;
+	}
+	.day-cell:not(.empty):not(.disabled):hover {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.day-cell.today {
+		font-weight: 700;
+		color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.day-cell.selected {
+		background: var(--ssk-colors-primary-500, #32a9ff) !important;
+		color: white !important;
+		font-weight: 600;
+	}
+	.day-cell.in-range {
+		background: var(--ssk-colors-primary-50, #eff6ff);
+		color: var(--ssk-colors-primary-700, #1d4ed8);
+		border-radius: 0;
+	}
+	.day-cell.disabled {
+		opacity: 0.35;
+		cursor: not-allowed;
+	}
+
+	/* Time */
+	.time-row {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+		margin-top: var(--dss-space-8, 8px);
+		padding-top: var(--dss-space-8, 8px);
+		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.time-input {
+		width: 48px;
+		height: 32px;
+		text-align: center;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-sm, 4px);
+		font-size: 14px;
+		font-family: inherit;
+		color: var(--ssk-colors-text-900, #111827);
+		outline: none;
+	}
+	.time-input:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.time-sep {
+		font-weight: 600;
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+
+	/* Footer */
+	.calendar-footer {
+		margin-top: var(--dss-space-8, 8px);
+		padding-top: var(--dss-space-8, 8px);
+		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		text-align: center;
+	}
+	.today-btn {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 500;
+		padding: 4px 12px;
+		border-radius: var(--dss-radius-sm, 4px);
+		transition: background 0.15s;
+	}
+	.today-btn:hover {
+		background: var(--ssk-colors-primary-50, #eff6ff);
+	}
+
+	/* Message */
+	.dss-datepicker-message {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+	.dss-datepicker-message.state-error { color: var(--ssk-colors-danger-500, #ef4444); }
+	.dss-datepicker-message.state-success { color: var(--ssk-colors-success-500, #10b981); }
+</style>

--- a/src/lib/svelte/form/DatePicker.svelte
+++ b/src/lib/svelte/form/DatePicker.svelte
@@ -284,13 +284,13 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-4, 4px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		position: relative;
 	}
 	.full-width { width: 100%; }
 
 	.dss-datepicker-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		line-height: 1.4;
@@ -304,7 +304,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--dss-space-8, 8px);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		cursor: pointer;
 		transition: border-color 0.15s, box-shadow 0.15s;
 		padding: 0 var(--dss-space-12, 12px);
@@ -323,7 +323,7 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-default.open, .variant-default:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 	.variant-outlined {
@@ -331,16 +331,16 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-outlined.open, .variant-outlined:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 	.variant-filled {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		border: 1px solid transparent;
 	}
 	.variant-filled.open, .variant-filled:focus {
 		background: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -362,7 +362,7 @@
 
 	.display-value {
 		flex: 1;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -380,7 +380,7 @@
 		cursor: pointer;
 		color: var(--ssk-colors-text-400, #9ca3af);
 		padding: 2px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		transition: color 0.15s;
 	}
 	.clear-btn:hover {
@@ -395,8 +395,8 @@
 		margin-top: 4px;
 		z-index: 50;
 		background: white;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-lg, 12px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 		padding: var(--dss-space-12, 12px);
 		min-width: 280px;
@@ -409,9 +409,9 @@
 		margin-bottom: var(--dss-space-8, 8px);
 	}
 	.month-year {
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 	}
 	.nav-btn {
 		display: flex;
@@ -420,14 +420,14 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		padding: 4px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		transition: background 0.15s, color 0.15s;
 	}
 	.nav-btn:hover {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
-		color: var(--ssk-colors-text-900, #111827);
+		background: var(--muted, #f3f4f6);
+		color: var(--foreground, #111827);
 	}
 
 	.calendar-grid {
@@ -449,7 +449,7 @@
 		justify-content: center;
 		width: 34px;
 		height: 34px;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		font-size: 13px;
 		color: var(--ssk-colors-text-700, #374151);
 		background: none;
@@ -462,14 +462,14 @@
 		cursor: default;
 	}
 	.day-cell:not(.empty):not(.disabled):hover {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 	.day-cell.today {
 		font-weight: 700;
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 	}
 	.day-cell.selected {
-		background: var(--ssk-colors-primary-500, #32a9ff) !important;
+		background: var(--primary, #32a9ff) !important;
 		color: white !important;
 		font-weight: 600;
 	}
@@ -491,43 +491,43 @@
 		gap: 4px;
 		margin-top: var(--dss-space-8, 8px);
 		padding-top: var(--dss-space-8, 8px);
-		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-top: 1px solid var(--border, #e5e7eb);
 	}
 	.time-input {
 		width: 48px;
 		height: 32px;
 		text-align: center;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		font-size: 14px;
 		font-family: inherit;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		outline: none;
 	}
 	.time-input:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 	.time-sep {
 		font-weight: 600;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 
 	/* Footer */
 	.calendar-footer {
 		margin-top: var(--dss-space-8, 8px);
 		padding-top: var(--dss-space-8, 8px);
-		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-top: 1px solid var(--border, #e5e7eb);
 		text-align: center;
 	}
 	.today-btn {
 		background: none;
 		border: none;
 		cursor: pointer;
-		color: var(--ssk-colors-primary-500, #32a9ff);
-		font-size: var(--dss-font-sm, 13px);
+		color: var(--primary, #32a9ff);
+		font-size: var(--text-sm, 13px);
 		font-weight: 500;
 		padding: 4px 12px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		transition: background 0.15s;
 	}
 	.today-btn:hover {
@@ -537,9 +537,9 @@
 	/* Message */
 	.dss-datepicker-message {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 	.dss-datepicker-message.state-error { color: var(--ssk-colors-danger-500, #ef4444); }
 	.dss-datepicker-message.state-success { color: var(--ssk-colors-success-500, #10b981); }

--- a/src/lib/svelte/form/FileUpload.svelte
+++ b/src/lib/svelte/form/FileUpload.svelte
@@ -186,7 +186,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--dss-space-8, 8px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.disabled { opacity: 0.5; pointer-events: none; }
 
@@ -199,7 +199,7 @@
 	}
 
 	.dss-fileupload-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
@@ -213,7 +213,7 @@
 		gap: var(--dss-space-8, 8px);
 		padding: var(--dss-space-24, 24px);
 		border: 2px dashed var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-lg, 12px);
+		border-radius: var(--radius-lg, 12px);
 		cursor: pointer;
 		transition: border-color 0.15s, background 0.15s;
 		background: var(--ssk-colors-neutral-50, #f9fafb);
@@ -228,15 +228,15 @@
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 	.dropzone-text {
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-p, 14px);
+		color: var(--muted-foreground, #6b7280);
 	}
 	.link-text {
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 		font-weight: 500;
 	}
 	.dropzone-desc {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 
@@ -248,8 +248,8 @@
 		padding: 8px 16px;
 		background: white;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
-		font-size: var(--dss-font-body, 14px);
+		border-radius: var(--radius-md, 8px);
+		font-size: var(--text-p, 14px);
 		color: var(--ssk-colors-text-700, #374151);
 		cursor: pointer;
 		font-family: inherit;
@@ -260,7 +260,7 @@
 		border-color: var(--ssk-colors-neutral-400, #9ca3af);
 	}
 	.btn-desc {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 
@@ -269,7 +269,7 @@
 		position: relative;
 		width: 80px;
 		height: 80px;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		border: 2px dashed var(--ssk-colors-neutral-300, #d1d5db);
 		background: var(--ssk-colors-neutral-50, #f9fafb);
 		display: flex;
@@ -321,13 +321,13 @@
 		gap: var(--dss-space-8, 8px);
 		padding: var(--dss-space-8, 8px);
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		border-radius: var(--dss-radius-md, 8px);
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
 	}
 	.file-thumb {
 		width: 32px;
 		height: 32px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		object-fit: cover;
 		flex-shrink: 0;
 	}
@@ -342,14 +342,14 @@
 		flex-direction: column;
 	}
 	.file-name {
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		color: var(--ssk-colors-text-700, #374151);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 	.file-size {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 	.file-remove {
@@ -361,7 +361,7 @@
 		cursor: pointer;
 		color: var(--ssk-colors-text-400, #9ca3af);
 		padding: 4px;
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		flex-shrink: 0;
 		transition: color 0.15s, background 0.15s;
 	}

--- a/src/lib/svelte/form/FileUpload.svelte
+++ b/src/lib/svelte/form/FileUpload.svelte
@@ -1,0 +1,372 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let accept: string = '';
+	export let maxSize: number | undefined = undefined;
+	export let multiple: boolean = false;
+	export let disabled: boolean = false;
+	export let variant: 'dropzone' | 'button' | 'avatar' = 'dropzone';
+	export let label: string = '';
+	export let description: string = '';
+
+	const dispatch = createEventDispatcher<{
+		change: File[];
+		remove: string;
+	}>();
+
+	let fileInputEl: HTMLInputElement;
+	let isDragging = false;
+	let files: { id: string; file: File; preview?: string }[] = [];
+
+	function generateId(): string {
+		return Math.random().toString(36).substring(2, 10);
+	}
+
+	function formatSize(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
+
+	function processFiles(incoming: FileList | null) {
+		if (!incoming) return;
+		const newFiles: { id: string; file: File; preview?: string }[] = [];
+		for (let i = 0; i < incoming.length; i++) {
+			const file = incoming[i];
+			if (maxSize && file.size > maxSize) continue;
+			const entry: { id: string; file: File; preview?: string } = { id: generateId(), file };
+			if (file.type.startsWith('image/')) {
+				entry.preview = URL.createObjectURL(file);
+			}
+			newFiles.push(entry);
+		}
+		if (multiple) {
+			files = [...files, ...newFiles];
+		} else {
+			files = newFiles.slice(0, 1);
+		}
+		dispatch('change', files.map((f) => f.file));
+	}
+
+	function handleInputChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		processFiles(input.files);
+		input.value = '';
+	}
+
+	function handleDrop(e: DragEvent) {
+		e.preventDefault();
+		isDragging = false;
+		if (disabled) return;
+		processFiles(e.dataTransfer?.files ?? null);
+	}
+
+	function handleDragOver(e: DragEvent) {
+		e.preventDefault();
+		if (!disabled) isDragging = true;
+	}
+
+	function handleDragLeave() {
+		isDragging = false;
+	}
+
+	function removeFile(id: string) {
+		const entry = files.find((f) => f.id === id);
+		if (entry?.preview) URL.revokeObjectURL(entry.preview);
+		files = files.filter((f) => f.id !== id);
+		dispatch('remove', id);
+		dispatch('change', files.map((f) => f.file));
+	}
+
+	function openPicker() {
+		if (!disabled) fileInputEl?.click();
+	}
+</script>
+
+<div class="dss-fileupload" class:disabled>
+	{#if label}
+		<span class="dss-fileupload-label">{label}</span>
+	{/if}
+
+	<input
+		bind:this={fileInputEl}
+		type="file"
+		{accept}
+		{multiple}
+		class="hidden-input"
+		on:change={handleInputChange}
+		{disabled}
+	/>
+
+	{#if variant === 'dropzone'}
+		<div
+			class="dss-fileupload-dropzone"
+			class:dragging={isDragging}
+			role="button"
+			tabindex="0"
+			on:click={openPicker}
+			on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') openPicker(); }}
+			on:drop={handleDrop}
+			on:dragover={handleDragOver}
+			on:dragleave={handleDragLeave}
+		>
+			<svg class="upload-icon" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+			</svg>
+			<span class="dropzone-text">Drag & drop files here, or <span class="link-text">browse</span></span>
+			{#if description}
+				<span class="dropzone-desc">{description}</span>
+			{/if}
+		</div>
+	{:else if variant === 'button'}
+		<button type="button" class="dss-fileupload-btn" on:click={openPicker} {disabled}>
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+			</svg>
+			Upload file{multiple ? 's' : ''}
+		</button>
+		{#if description}
+			<span class="btn-desc">{description}</span>
+		{/if}
+	{:else if variant === 'avatar'}
+		<button
+			type="button"
+			class="dss-fileupload-avatar"
+			on:click={openPicker}
+			{disabled}
+		>
+			{#if files.length > 0 && files[0].preview}
+				<img src={files[0].preview} alt="Avatar preview" class="avatar-preview" />
+			{:else}
+				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+				</svg>
+			{/if}
+			<span class="avatar-overlay">
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" /><circle cx="12" cy="13" r="4" />
+				</svg>
+			</span>
+		</button>
+	{/if}
+
+	{#if files.length > 0 && variant !== 'avatar'}
+		<ul class="dss-fileupload-list">
+			{#each files as entry (entry.id)}
+				<li class="file-item">
+					{#if entry.preview}
+						<img src={entry.preview} alt={entry.file.name} class="file-thumb" />
+					{:else}
+						<svg class="file-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" />
+						</svg>
+					{/if}
+					<div class="file-info">
+						<span class="file-name">{entry.file.name}</span>
+						<span class="file-size">{formatSize(entry.file.size)}</span>
+					</div>
+					<button
+						type="button"
+						class="file-remove"
+						aria-label="Remove file"
+						on:click={() => removeFile(entry.id)}
+					>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+							<line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+						</svg>
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>
+
+<style>
+	.dss-fileupload {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-8, 8px);
+		font-family: 'Inter', sans-serif;
+	}
+	.disabled { opacity: 0.5; pointer-events: none; }
+
+	.hidden-input {
+		position: absolute;
+		width: 0;
+		height: 0;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.dss-fileupload-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	/* Dropzone */
+	.dss-fileupload-dropzone {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--dss-space-8, 8px);
+		padding: var(--dss-space-24, 24px);
+		border: 2px dashed var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-lg, 12px);
+		cursor: pointer;
+		transition: border-color 0.15s, background 0.15s;
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+	.dss-fileupload-dropzone:hover,
+	.dss-fileupload-dropzone.dragging {
+		border-color: var(--ssk-colors-primary-400, #60a5fa);
+		background: var(--ssk-colors-primary-50, #eff6ff);
+	}
+
+	.upload-icon {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	.dropzone-text {
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+	.link-text {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		font-weight: 500;
+	}
+	.dropzone-desc {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	/* Button variant */
+	.dss-fileupload-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		padding: 8px 16px;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-700, #374151);
+		cursor: pointer;
+		font-family: inherit;
+		transition: background 0.15s, border-color 0.15s;
+	}
+	.dss-fileupload-btn:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		border-color: var(--ssk-colors-neutral-400, #9ca3af);
+	}
+	.btn-desc {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	/* Avatar variant */
+	.dss-fileupload-avatar {
+		position: relative;
+		width: 80px;
+		height: 80px;
+		border-radius: var(--dss-radius-full, 9999px);
+		border: 2px dashed var(--ssk-colors-neutral-300, #d1d5db);
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		overflow: hidden;
+		transition: border-color 0.15s;
+		padding: 0;
+	}
+	.dss-fileupload-avatar:hover {
+		border-color: var(--ssk-colors-primary-400, #60a5fa);
+	}
+	.dss-fileupload-avatar svg {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	.avatar-preview {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.avatar-overlay {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.4);
+		opacity: 0;
+		transition: opacity 0.15s;
+		color: white;
+	}
+	.dss-fileupload-avatar:hover .avatar-overlay {
+		opacity: 1;
+	}
+
+	/* File list */
+	.dss-fileupload-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+	}
+	.file-item {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		padding: var(--dss-space-8, 8px);
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.file-thumb {
+		width: 32px;
+		height: 32px;
+		border-radius: var(--dss-radius-sm, 4px);
+		object-fit: cover;
+		flex-shrink: 0;
+	}
+	.file-icon {
+		flex-shrink: 0;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	.file-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+	}
+	.file-name {
+		font-size: var(--dss-font-sm, 13px);
+		color: var(--ssk-colors-text-700, #374151);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.file-size {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	.file-remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 4px;
+		border-radius: var(--dss-radius-sm, 4px);
+		flex-shrink: 0;
+		transition: color 0.15s, background 0.15s;
+	}
+	.file-remove:hover {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		background: var(--ssk-colors-danger-50, #fef2f2);
+	}
+</style>

--- a/src/lib/svelte/form/FormError.svelte
+++ b/src/lib/svelte/form/FormError.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	export let message: string | undefined = undefined;
+</script>
+
+{#if message}
+	<p class="dss-form-error">{message}</p>
+{/if}
+
+<style>
+	.dss-form-error {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+		color: var(--ssk-colors-danger-500, #ef4444);
+	}
+</style>

--- a/src/lib/svelte/form/FormError.svelte
+++ b/src/lib/svelte/form/FormError.svelte
@@ -9,7 +9,7 @@
 <style>
 	.dss-form-error {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
 		color: var(--ssk-colors-danger-500, #ef4444);
 	}

--- a/src/lib/svelte/form/FormField.svelte
+++ b/src/lib/svelte/form/FormField.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	export let name: string;
+	export let label: string | undefined = undefined;
+	export let required: boolean = false;
+	export let error: string | undefined = undefined;
+	export let successMessage: string | undefined = undefined;
+	export let helperText: string | undefined = undefined;
+	export let layout: 'vertical' | 'horizontal' = 'vertical';
+	export let labelWidth: string = '160px';
+</script>
+
+<div
+	class="dss-form-field layout-{layout}"
+	style={layout === 'horizontal' ? `--label-width: ${labelWidth}` : undefined}
+>
+	{#if label}
+		<label class="dss-form-field-label" for={name}>
+			{label}
+			{#if required}
+				<span class="required-mark" aria-hidden="true">*</span>
+			{/if}
+		</label>
+	{/if}
+
+	<div class="dss-form-field-content">
+		<slot />
+
+		{#if error}
+			<p class="dss-form-field-message state-error">{error}</p>
+		{:else if successMessage}
+			<p class="dss-form-field-message state-success">{successMessage}</p>
+		{:else if helperText}
+			<p class="dss-form-field-message state-helper">{helperText}</p>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.dss-form-field {
+		display: flex;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Vertical layout */
+	.layout-vertical {
+		flex-direction: column;
+		gap: var(--dss-space-2, 6px);
+	}
+
+	/* Horizontal layout */
+	.layout-horizontal {
+		flex-direction: row;
+		align-items: flex-start;
+		gap: var(--dss-space-4, 12px);
+	}
+	.layout-horizontal > .dss-form-field-label {
+		width: var(--label-width, 160px);
+		flex-shrink: 0;
+		padding-top: var(--dss-space-2, 6px);
+	}
+	.layout-horizontal > .dss-form-field-content {
+		flex: 1;
+		min-width: 0;
+	}
+
+	/* Label */
+	.dss-form-field-label {
+		font-size: var(--dss-font-label, 12px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.required-mark {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		margin-left: 2px;
+	}
+
+	/* Content */
+	.dss-form-field-content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-2, 6px);
+	}
+
+	/* Messages */
+	.dss-form-field-message {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+	}
+	.state-error {
+		color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.state-success {
+		color: var(--ssk-colors-success-500, #10b981);
+	}
+	.state-helper {
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+</style>

--- a/src/lib/svelte/form/FormField.svelte
+++ b/src/lib/svelte/form/FormField.svelte
@@ -38,7 +38,7 @@
 <style>
 	.dss-form-field {
 		display: flex;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Vertical layout */
@@ -65,7 +65,7 @@
 
 	/* Label */
 	.dss-form-field-label {
-		font-size: var(--dss-font-label, 12px);
+		font-size: var(--text-label, 12px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		line-height: 1.4;
@@ -85,7 +85,7 @@
 	/* Messages */
 	.dss-form-field-message {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
 	}
 	.state-error {
@@ -95,6 +95,6 @@
 		color: var(--ssk-colors-success-500, #10b981);
 	}
 	.state-helper {
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 </style>

--- a/src/lib/svelte/form/FormHelperText.svelte
+++ b/src/lib/svelte/form/FormHelperText.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+</script>
+
+<p class="dss-form-helper-text">
+	<slot />
+</p>
+
+<style>
+	.dss-form-helper-text {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+</style>

--- a/src/lib/svelte/form/FormHelperText.svelte
+++ b/src/lib/svelte/form/FormHelperText.svelte
@@ -8,8 +8,8 @@
 <style>
 	.dss-form-helper-text {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 </style>

--- a/src/lib/svelte/form/FormLabel.svelte
+++ b/src/lib/svelte/form/FormLabel.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	export let htmlFor: string | undefined = undefined;
+	export let required: boolean = false;
+</script>
+
+<label class="dss-form-label" for={htmlFor}>
+	<slot />
+	{#if required}
+		<span class="required-mark" aria-hidden="true">*</span>
+	{/if}
+</label>
+
+<style>
+	.dss-form-label {
+		font-size: var(--dss-font-label, 12px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.required-mark {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		margin-left: 2px;
+	}
+</style>

--- a/src/lib/svelte/form/FormLabel.svelte
+++ b/src/lib/svelte/form/FormLabel.svelte
@@ -12,7 +12,7 @@
 
 <style>
 	.dss-form-label {
-		font-size: var(--dss-font-label, 12px);
+		font-size: var(--text-label, 12px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		line-height: 1.4;

--- a/src/lib/svelte/form/Input.svelte
+++ b/src/lib/svelte/form/Input.svelte
@@ -125,13 +125,13 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-1, 4px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.full-width { width: 100%; }
 
 	/* Label */
 	.dss-input-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		line-height: 1.4;
@@ -145,7 +145,7 @@
 	.dss-input {
 		display: flex;
 		align-items: center;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
 		overflow: hidden;
 	}
@@ -161,7 +161,7 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-default:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -170,17 +170,17 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-outlined:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
 	.variant-filled {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		border: 1px solid transparent;
 	}
 	.variant-filled:focus-within:not(.disabled) {
 		background: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -189,7 +189,7 @@
 		border: 1px solid transparent;
 	}
 	.variant-ghost:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	/* States */
@@ -233,7 +233,7 @@
 		border: none;
 		outline: none;
 		background: transparent;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		font-size: inherit;
 		font-family: inherit;
 		padding: 0 var(--dss-space-4, 12px);
@@ -262,7 +262,7 @@
 	.input-affix {
 		display: flex;
 		align-items: center;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		font-size: inherit;
 		flex-shrink: 0;
 		user-select: none;
@@ -300,9 +300,9 @@
 	/* Message */
 	.dss-input-message {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 	.dss-input-message.state-error {
 		color: var(--ssk-colors-danger-500, #ef4444);

--- a/src/lib/svelte/form/Input.svelte
+++ b/src/lib/svelte/form/Input.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: string = '';
+	export let label: string = '';
+	export let placeholder: string = '';
+	export let helperText: string = '';
+	export let errorMessage: string = '';
+	export let successMessage: string = '';
+	export let inputSize: 'sm' | 'md' | 'lg' = 'md';
+	export let variant: 'default' | 'outlined' | 'filled' | 'ghost' = 'default';
+	export let state: 'default' | 'error' | 'success' | 'warning' = 'default';
+	export let disabled: boolean = false;
+	export let required: boolean = false;
+	export let clearable: boolean = false;
+	export let loading: boolean = false;
+	export let fullWidth: boolean = false;
+	export let type: string = 'text';
+	export let prefix: string = '';
+	export let suffix: string = '';
+
+	const dispatch = createEventDispatcher<{
+		input: Event;
+		change: Event;
+		focus: FocusEvent;
+		blur: FocusEvent;
+		clear: void;
+	}>();
+
+	let inputEl: HTMLInputElement;
+
+	$: computedState = errorMessage ? 'error' : successMessage ? 'success' : state;
+	$: message = errorMessage || successMessage || helperText;
+
+	function handleInput(e: Event) {
+		value = (e.target as HTMLInputElement).value;
+		dispatch('input', e);
+	}
+
+	function handleClear() {
+		value = '';
+		dispatch('clear');
+		inputEl?.focus();
+	}
+</script>
+
+<div class="dss-input-wrapper" class:full-width={fullWidth}>
+	{#if label}
+		<label class="dss-input-label">
+			{label}
+			{#if required}
+				<span class="required-mark" aria-hidden="true">*</span>
+			{/if}
+		</label>
+	{/if}
+
+	<div
+		class="dss-input size-{inputSize} variant-{variant} state-{computedState}"
+		class:disabled
+		class:has-prefix={prefix || $$slots.leftIcon}
+		class:has-suffix={suffix || $$slots.rightIcon || clearable || loading}
+	>
+		{#if $$slots.leftIcon}
+			<span class="input-icon left" aria-hidden="true">
+				<slot name="leftIcon" />
+			</span>
+		{/if}
+
+		{#if prefix}
+			<span class="input-affix prefix" aria-hidden="true">{prefix}</span>
+		{/if}
+
+		<input
+			bind:this={inputEl}
+			value={value}
+			{type}
+			{placeholder}
+			{disabled}
+			{required}
+			aria-invalid={computedState === 'error'}
+			aria-describedby={message ? 'input-message' : undefined}
+			on:input={handleInput}
+			on:change={(e) => dispatch('change', e)}
+			on:focus={(e) => dispatch('focus', e)}
+			on:blur={(e) => dispatch('blur', e)}
+		/>
+
+		{#if suffix}
+			<span class="input-affix suffix" aria-hidden="true">{suffix}</span>
+		{/if}
+
+		{#if loading}
+			<span class="input-icon right" aria-hidden="true">
+				<svg class="spinner" width="16" height="16" viewBox="0 0 24 24" fill="none">
+					<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.25" stroke-width="3" />
+					<path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+				</svg>
+			</span>
+		{:else if clearable && value && !disabled}
+			<button
+				class="input-clear"
+				type="button"
+				tabindex="-1"
+				aria-label="Clear input"
+				on:click={handleClear}
+			>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+				</svg>
+			</button>
+		{:else if $$slots.rightIcon}
+			<span class="input-icon right" aria-hidden="true">
+				<slot name="rightIcon" />
+			</span>
+		{/if}
+	</div>
+
+	{#if message}
+		<p class="dss-input-message state-{computedState}" id="input-message">{message}</p>
+	{/if}
+</div>
+
+<style>
+	.dss-input-wrapper {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-1, 4px);
+		font-family: 'Inter', sans-serif;
+	}
+	.full-width { width: 100%; }
+
+	/* Label */
+	.dss-input-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.required-mark {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		margin-left: 2px;
+	}
+
+	/* Container */
+	.dss-input {
+		display: flex;
+		align-items: center;
+		border-radius: var(--dss-radius-md, 8px);
+		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+		overflow: hidden;
+	}
+
+	/* Sizes */
+	.size-sm { height: 32px; font-size: 13px; }
+	.size-md { height: 36px; font-size: 14px; }
+	.size-lg { height: 40px; font-size: 15px; }
+
+	/* Variants */
+	.variant-default {
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-default:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-outlined {
+		background: transparent;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outlined:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-filled {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border: 1px solid transparent;
+	}
+	.variant-filled:focus-within:not(.disabled) {
+		background: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-ghost {
+		background: transparent;
+		border: 1px solid transparent;
+	}
+	.variant-ghost:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* States */
+	.state-error:not(.disabled) {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.state-error:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+		box-shadow: 0 0 0 2px var(--ssk-colors-danger-50, #fef2f2);
+	}
+
+	.state-success:not(.disabled) {
+		border-color: var(--ssk-colors-success-500, #10b981);
+	}
+	.state-success:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-success-500, #10b981);
+		box-shadow: 0 0 0 2px var(--ssk-colors-success-50, #ecfdf5);
+	}
+
+	.state-warning:not(.disabled) {
+		border-color: var(--ssk-colors-warning-500, #f59e0b);
+	}
+	.state-warning:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-warning-500, #f59e0b);
+		box-shadow: 0 0 0 2px var(--ssk-colors-warning-50, #fffbeb);
+	}
+
+	/* Disabled */
+	.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		background: var(--dss-bg-disabled, #f9fafb);
+	}
+	.disabled input {
+		cursor: not-allowed;
+	}
+
+	/* Input element */
+	.dss-input input {
+		flex: 1;
+		border: none;
+		outline: none;
+		background: transparent;
+		color: var(--ssk-colors-text-900, #111827);
+		font-size: inherit;
+		font-family: inherit;
+		padding: 0 var(--dss-space-4, 12px);
+		height: 100%;
+		width: 100%;
+		min-width: 0;
+	}
+	.dss-input input::placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.has-prefix input { padding-left: var(--dss-space-1, 4px); }
+	.has-suffix input { padding-right: var(--dss-space-1, 4px); }
+
+	/* Icons & affixes */
+	.input-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+	}
+	.input-icon.left { padding-left: var(--dss-space-4, 12px); }
+	.input-icon.right { padding-right: var(--dss-space-4, 12px); }
+
+	.input-affix {
+		display: flex;
+		align-items: center;
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: inherit;
+		flex-shrink: 0;
+		user-select: none;
+	}
+	.prefix { padding-left: var(--dss-space-4, 12px); }
+	.suffix { padding-right: var(--dss-space-4, 12px); }
+
+	/* Clear button */
+	.input-clear {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 0 var(--dss-space-4, 12px);
+		height: 100%;
+		flex-shrink: 0;
+		transition: color 0.15s;
+	}
+	.input-clear:hover {
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	/* Spinner */
+	.spinner {
+		animation: dss-input-spin 0.8s linear infinite;
+	}
+	@keyframes dss-input-spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+
+	/* Message */
+	.dss-input-message {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+	.dss-input-message.state-error {
+		color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.dss-input-message.state-success {
+		color: var(--ssk-colors-success-500, #10b981);
+	}
+	.dss-input-message.state-warning {
+		color: var(--ssk-colors-warning-500, #f59e0b);
+	}
+</style>

--- a/src/lib/svelte/form/OTPInput.svelte
+++ b/src/lib/svelte/form/OTPInput.svelte
@@ -118,12 +118,12 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-8, 8px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.disabled { opacity: 0.5; pointer-events: none; }
 
 	.dss-otp-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
@@ -136,14 +136,14 @@
 	.dss-otp-digit {
 		text-align: center;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		background: white;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		font-weight: 600;
 		font-family: inherit;
 		outline: none;
 		transition: border-color 0.15s, box-shadow 0.15s;
-		caret-color: var(--ssk-colors-primary-500, #32a9ff);
+		caret-color: var(--primary, #32a9ff);
 	}
 
 	.size-sm { width: 36px; height: 36px; font-size: 16px; }
@@ -151,7 +151,7 @@
 	.size-lg { width: 52px; height: 52px; font-size: 24px; }
 
 	.dss-otp-digit:focus {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -169,7 +169,7 @@
 
 	.dss-otp-error {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-danger-500, #ef4444);
 		line-height: 1.4;
 	}

--- a/src/lib/svelte/form/OTPInput.svelte
+++ b/src/lib/svelte/form/OTPInput.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import { createEventDispatcher, tick } from 'svelte';
+
+	export let length: number = 6;
+	export let value: string = '';
+	export let disabled: boolean = false;
+	export let error: string = '';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let label: string = '';
+	export let masked: boolean = false;
+
+	const dispatch = createEventDispatcher<{
+		change: string;
+		complete: string;
+	}>();
+
+	let inputs: HTMLInputElement[] = [];
+	let digits: string[] = [];
+
+	$: {
+		digits = Array.from({ length }, (_, i) => value[i] || '');
+	}
+
+	function focusInput(index: number) {
+		tick().then(() => {
+			if (inputs[index]) inputs[index].focus();
+		});
+	}
+
+	function updateValue() {
+		value = digits.join('');
+		dispatch('change', value);
+		if (value.length === length && !value.includes('')) {
+			dispatch('complete', value);
+		}
+	}
+
+	function handleInput(index: number, e: Event) {
+		const input = e.target as HTMLInputElement;
+		const char = input.value.replace(/\D/g, '').slice(-1);
+		digits[index] = char;
+		digits = [...digits];
+		updateValue();
+		if (char && index < length - 1) {
+			focusInput(index + 1);
+		}
+	}
+
+	function handleKeydown(index: number, e: KeyboardEvent) {
+		if (e.key === 'Backspace') {
+			e.preventDefault();
+			if (digits[index]) {
+				digits[index] = '';
+				digits = [...digits];
+				updateValue();
+			} else if (index > 0) {
+				digits[index - 1] = '';
+				digits = [...digits];
+				updateValue();
+				focusInput(index - 1);
+			}
+		} else if (e.key === 'ArrowLeft' && index > 0) {
+			focusInput(index - 1);
+		} else if (e.key === 'ArrowRight' && index < length - 1) {
+			focusInput(index + 1);
+		}
+	}
+
+	function handlePaste(e: ClipboardEvent) {
+		e.preventDefault();
+		const pasted = (e.clipboardData?.getData('text') || '').replace(/\D/g, '').slice(0, length);
+		for (let i = 0; i < length; i++) {
+			digits[i] = pasted[i] || '';
+		}
+		digits = [...digits];
+		updateValue();
+		const nextEmpty = digits.findIndex((d) => !d);
+		focusInput(nextEmpty >= 0 ? nextEmpty : length - 1);
+	}
+
+	function handleFocus(e: FocusEvent) {
+		(e.target as HTMLInputElement).select();
+	}
+</script>
+
+<div class="dss-otp" class:disabled>
+	{#if label}
+		<span class="dss-otp-label">{label}</span>
+	{/if}
+
+	<div class="dss-otp-inputs" on:paste={handlePaste}>
+		{#each Array(length) as _, i}
+			<input
+				bind:this={inputs[i]}
+				type={masked ? 'password' : 'text'}
+				inputmode="numeric"
+				maxlength="1"
+				class="dss-otp-digit size-{size}"
+				class:has-value={!!digits[i]}
+				class:error={!!error}
+				value={digits[i]}
+				{disabled}
+				autocomplete="one-time-code"
+				on:input={(e) => handleInput(i, e)}
+				on:keydown={(e) => handleKeydown(i, e)}
+				on:focus={handleFocus}
+			/>
+		{/each}
+	</div>
+
+	{#if error}
+		<p class="dss-otp-error">{error}</p>
+	{/if}
+</div>
+
+<style>
+	.dss-otp {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-8, 8px);
+		font-family: 'Inter', sans-serif;
+	}
+	.disabled { opacity: 0.5; pointer-events: none; }
+
+	.dss-otp-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.dss-otp-inputs {
+		display: flex;
+		gap: var(--dss-space-8, 8px);
+	}
+
+	.dss-otp-digit {
+		text-align: center;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		background: white;
+		color: var(--ssk-colors-text-900, #111827);
+		font-weight: 600;
+		font-family: inherit;
+		outline: none;
+		transition: border-color 0.15s, box-shadow 0.15s;
+		caret-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.size-sm { width: 36px; height: 36px; font-size: 16px; }
+	.size-md { width: 44px; height: 44px; font-size: 20px; }
+	.size-lg { width: 52px; height: 52px; font-size: 24px; }
+
+	.dss-otp-digit:focus {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.dss-otp-digit.has-value {
+		border-color: var(--ssk-colors-neutral-400, #9ca3af);
+	}
+
+	.dss-otp-digit.error {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.dss-otp-digit.error:focus {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+		box-shadow: 0 0 0 2px var(--ssk-colors-danger-50, #fef2f2);
+	}
+
+	.dss-otp-error {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-danger-500, #ef4444);
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/svelte/form/Radio.svelte
+++ b/src/lib/svelte/form/Radio.svelte
@@ -78,7 +78,7 @@
 		align-items: flex-start;
 		gap: var(--dss-space-2, 8px);
 		cursor: pointer;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		user-select: none;
 	}
 	.dss-radio.disabled {
@@ -113,7 +113,7 @@
 	.radio-circle:focus-visible {
 		outline: none;
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	.dss-radio:not(.disabled):hover .radio-circle:not(.checked) {
@@ -121,7 +121,7 @@
 	}
 
 	.radio-circle.checked {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 	.dss-radio:not(.disabled):hover .radio-circle.checked {
 		border-color: var(--ssk-colors-primary-600, #1b8bf5);
@@ -130,7 +130,7 @@
 	/* Dot */
 	.radio-dot {
 		border-radius: 50%;
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		transition: transform 0.15s;
 	}
 	.dss-radio:not(.disabled):hover .radio-dot {
@@ -153,8 +153,8 @@
 	.size-lg .radio-label { font-size: 15px; }
 
 	.radio-description {
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-caption, 12px);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.4;
 	}
 </style>

--- a/src/lib/svelte/form/Radio.svelte
+++ b/src/lib/svelte/form/Radio.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: string;
+	export let label: string = '';
+	export let description: string = '';
+	export let disabled: boolean = false;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let name: string = '';
+	export let checked: boolean = false;
+
+	const dispatch = createEventDispatcher<{ change: { value: string } }>();
+
+	const sizeMap = { sm: 16, md: 18, lg: 20 };
+	$: circleSize = sizeMap[size];
+	$: dotSize = Math.round(circleSize * 0.45);
+
+	function handleChange() {
+		if (disabled) return;
+		checked = true;
+		dispatch('change', { value });
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === ' ' || e.key === 'Enter') {
+			e.preventDefault();
+			handleChange();
+		}
+	}
+</script>
+
+<label
+	class="dss-radio size-{size}"
+	class:disabled
+>
+	<span
+		class="radio-circle"
+		class:checked
+		role="radio"
+		aria-checked={checked}
+		aria-disabled={disabled}
+		tabindex={disabled ? -1 : 0}
+		style="width: {circleSize}px; height: {circleSize}px;"
+		on:click={handleChange}
+		on:keydown={handleKeydown}
+	>
+		{#if checked}
+			<span class="radio-dot" style="width: {dotSize}px; height: {dotSize}px;" />
+		{/if}
+	</span>
+
+	{#if label || description}
+		<span class="radio-content">
+			{#if label}
+				<span class="radio-label">{label}</span>
+			{/if}
+			{#if description}
+				<span class="radio-description">{description}</span>
+			{/if}
+		</span>
+	{/if}
+
+	<input
+		type="radio"
+		{name}
+		{value}
+		checked={checked}
+		{disabled}
+		class="sr-only"
+		tabindex="-1"
+		aria-hidden="true"
+	/>
+</label>
+
+<style>
+	.dss-radio {
+		display: inline-flex;
+		align-items: flex-start;
+		gap: var(--dss-space-2, 8px);
+		cursor: pointer;
+		font-family: 'Inter', sans-serif;
+		user-select: none;
+	}
+	.dss-radio.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	/* Circle */
+	.radio-circle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: 2px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: 50%;
+		background: white;
+		flex-shrink: 0;
+		transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+		margin-top: 1px;
+	}
+	.radio-circle:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.dss-radio:not(.disabled):hover .radio-circle:not(.checked) {
+		border-color: var(--ssk-colors-primary-400, #60bfff);
+	}
+
+	.radio-circle.checked {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.dss-radio:not(.disabled):hover .radio-circle.checked {
+		border-color: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	/* Dot */
+	.radio-dot {
+		border-radius: 50%;
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		transition: transform 0.15s;
+	}
+	.dss-radio:not(.disabled):hover .radio-dot {
+		background: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	/* Content */
+	.radio-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.radio-label {
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.size-sm .radio-label { font-size: 13px; }
+	.size-md .radio-label { font-size: 14px; }
+	.size-lg .radio-label { font-size: 15px; }
+
+	.radio-description {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/svelte/form/RadioGroup.svelte
+++ b/src/lib/svelte/form/RadioGroup.svelte
@@ -56,11 +56,11 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--dss-space-2, 8px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.dss-radio-group-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		padding: 0;
@@ -82,7 +82,7 @@
 
 	.dss-radio-group-error {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-danger-500, #ef4444);
 		line-height: 1.4;
 	}

--- a/src/lib/svelte/form/RadioGroup.svelte
+++ b/src/lib/svelte/form/RadioGroup.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { createEventDispatcher, setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+
+	export let name: string;
+	export let value: string = '';
+	export let label: string = '';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let disabled: boolean = false;
+	export let direction: 'horizontal' | 'vertical' = 'vertical';
+	export let error: string = '';
+
+	const dispatch = createEventDispatcher<{ change: string }>();
+
+	const groupValue = writable(value);
+
+	$: groupValue.set(value);
+
+	setContext('radioGroup', {
+		name,
+		groupValue,
+		disabled,
+		size,
+		select(val: string) {
+			value = val;
+			groupValue.set(val);
+			dispatch('change', val);
+		}
+	});
+</script>
+
+<fieldset
+	class="dss-radio-group"
+	role="radiogroup"
+	aria-label={label || undefined}
+	aria-invalid={!!error || undefined}
+>
+	{#if label}
+		<legend class="dss-radio-group-label">{label}</legend>
+	{/if}
+
+	<div class="dss-radio-group-items direction-{direction}">
+		<slot />
+	</div>
+
+	{#if error}
+		<p class="dss-radio-group-error">{error}</p>
+	{/if}
+</fieldset>
+
+<style>
+	.dss-radio-group {
+		border: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-2, 8px);
+		font-family: 'Inter', sans-serif;
+	}
+
+	.dss-radio-group-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		padding: 0;
+		line-height: 1.4;
+	}
+
+	.dss-radio-group-items {
+		display: flex;
+	}
+	.direction-vertical {
+		flex-direction: column;
+		gap: var(--dss-space-4, 12px);
+	}
+	.direction-horizontal {
+		flex-direction: row;
+		flex-wrap: wrap;
+		gap: var(--dss-space-6, 16px);
+	}
+
+	.dss-radio-group-error {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-danger-500, #ef4444);
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/svelte/form/SearchField.svelte
+++ b/src/lib/svelte/form/SearchField.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	export let value: string = '';
+	export let placeholder: string = 'Search...';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let variant: 'default' | 'outlined' | 'filled' = 'default';
+	export let loading: boolean = false;
+	export let clearable: boolean = true;
+	export let disabled: boolean = false;
+	export let autoFocus: boolean = false;
+	export let debounce: number = 300;
+
+	const dispatch = createEventDispatcher<{
+		input: string;
+		search: string;
+		clear: void;
+	}>();
+
+	let inputEl: HTMLInputElement;
+	let debounceTimer: ReturnType<typeof setTimeout>;
+
+	onMount(() => {
+		if (autoFocus && inputEl) {
+			inputEl.focus();
+		}
+	});
+
+	function handleInput(e: Event) {
+		const target = e.target as HTMLInputElement;
+		value = target.value;
+
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => {
+			dispatch('input', value);
+			dispatch('search', value);
+		}, debounce);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			clearTimeout(debounceTimer);
+			dispatch('search', value);
+		}
+	}
+
+	function handleClear() {
+		value = '';
+		clearTimeout(debounceTimer);
+		dispatch('clear');
+		dispatch('input', '');
+		dispatch('search', '');
+		inputEl?.focus();
+	}
+</script>
+
+<div
+	class="dss-search-field size-{size} variant-{variant}"
+	class:disabled
+>
+	<span class="search-icon" aria-hidden="true">
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<circle cx="11" cy="11" r="8" />
+			<line x1="21" y1="21" x2="16.65" y2="16.65" />
+		</svg>
+	</span>
+
+	<input
+		bind:this={inputEl}
+		type="search"
+		{value}
+		{placeholder}
+		{disabled}
+		aria-label={placeholder}
+		on:input={handleInput}
+		on:keydown={handleKeydown}
+	/>
+
+	{#if loading}
+		<span class="trailing-icon" aria-hidden="true">
+			<svg class="spinner" width="16" height="16" viewBox="0 0 24 24" fill="none">
+				<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.25" stroke-width="3" />
+				<path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+			</svg>
+		</span>
+	{:else if clearable && value && !disabled}
+		<button
+			class="clear-btn"
+			type="button"
+			tabindex="-1"
+			aria-label="Clear search"
+			on:click={handleClear}
+		>
+			<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+				<line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+			</svg>
+		</button>
+	{/if}
+</div>
+
+<style>
+	.dss-search-field {
+		display: flex;
+		align-items: center;
+		border-radius: var(--dss-radius-md, 8px);
+		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+		overflow: hidden;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Sizes */
+	.size-sm { height: 32px; font-size: var(--dss-font-sm, 13px); }
+	.size-md { height: 36px; font-size: var(--dss-font-body, 14px); }
+	.size-lg { height: 40px; font-size: 15px; }
+
+	/* Variants */
+	.variant-default {
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-default:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-outlined {
+		background: transparent;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outlined:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-filled {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border: 1px solid transparent;
+	}
+	.variant-filled:focus-within:not(.disabled) {
+		background: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	/* Disabled */
+	.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		background: var(--dss-bg-disabled, #f9fafb);
+	}
+	.disabled input {
+		cursor: not-allowed;
+	}
+
+	/* Search icon */
+	.search-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+		padding-left: var(--dss-space-4, 12px);
+	}
+
+	/* Input */
+	.dss-search-field input {
+		flex: 1;
+		border: none;
+		outline: none;
+		background: transparent;
+		color: var(--ssk-colors-text-900, #111827);
+		font-size: inherit;
+		font-family: inherit;
+		padding: 0 var(--dss-space-4, 12px);
+		padding-left: var(--dss-space-2, 6px);
+		height: 100%;
+		width: 100%;
+		min-width: 0;
+	}
+	.dss-search-field input::placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+	/* Hide native search clear button */
+	.dss-search-field input[type='search']::-webkit-search-cancel-button {
+		-webkit-appearance: none;
+		appearance: none;
+	}
+
+	/* Trailing icon */
+	.trailing-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+		padding-right: var(--dss-space-4, 12px);
+	}
+
+	/* Clear button */
+	.clear-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 0 var(--dss-space-4, 12px);
+		height: 100%;
+		flex-shrink: 0;
+		transition: color 0.15s;
+	}
+	.clear-btn:hover {
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	/* Spinner */
+	.spinner {
+		animation: dss-search-spin 0.8s linear infinite;
+	}
+	@keyframes dss-search-spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/src/lib/svelte/form/SearchField.svelte
+++ b/src/lib/svelte/form/SearchField.svelte
@@ -102,15 +102,15 @@
 	.dss-search-field {
 		display: flex;
 		align-items: center;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
 		overflow: hidden;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Sizes */
-	.size-sm { height: 32px; font-size: var(--dss-font-sm, 13px); }
-	.size-md { height: 36px; font-size: var(--dss-font-body, 14px); }
+	.size-sm { height: 32px; font-size: var(--text-sm, 13px); }
+	.size-md { height: 36px; font-size: var(--text-p, 14px); }
 	.size-lg { height: 40px; font-size: 15px; }
 
 	/* Variants */
@@ -119,7 +119,7 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-default:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -128,17 +128,17 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-outlined:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
 	.variant-filled {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		border: 1px solid transparent;
 	}
 	.variant-filled:focus-within:not(.disabled) {
 		background: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -168,7 +168,7 @@
 		border: none;
 		outline: none;
 		background: transparent;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		font-size: inherit;
 		font-family: inherit;
 		padding: 0 var(--dss-space-4, 12px);

--- a/src/lib/svelte/form/Switch.svelte
+++ b/src/lib/svelte/form/Switch.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let checked: boolean = false;
+	export let label: string = '';
+	export let description: string = '';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let disabled: boolean = false;
+	export let color: string = 'primary';
+
+	const dispatch = createEventDispatcher<{ change: { checked: boolean } }>();
+
+	const trackWidthMap = { sm: 28, md: 36, lg: 44 };
+	const trackHeightMap = { sm: 16, md: 20, lg: 24 };
+	const thumbSizeMap = { sm: 12, md: 16, lg: 20 };
+
+	$: trackWidth = trackWidthMap[size];
+	$: trackHeight = trackHeightMap[size];
+	$: thumbSize = thumbSizeMap[size];
+	$: thumbOffset = trackWidth - thumbSize - 4; /* 2px padding each side */
+
+	function handleToggle() {
+		if (disabled) return;
+		checked = !checked;
+		dispatch('change', { checked });
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === ' ' || e.key === 'Enter') {
+			e.preventDefault();
+			handleToggle();
+		}
+	}
+</script>
+
+<label
+	class="dss-switch size-{size}"
+	class:disabled
+>
+	<span
+		class="switch-track"
+		class:checked
+		role="switch"
+		aria-checked={checked}
+		aria-disabled={disabled}
+		tabindex={disabled ? -1 : 0}
+		style="
+			width: {trackWidth}px;
+			height: {trackHeight}px;
+			{checked ? `background: var(--ssk-colors-${color}-500, var(--ssk-colors-primary-500, #32a9ff));` : ''}
+		"
+		on:click={handleToggle}
+		on:keydown={handleKeydown}
+	>
+		<span
+			class="switch-thumb"
+			style="
+				width: {thumbSize}px;
+				height: {thumbSize}px;
+				transform: translateX({checked ? thumbOffset : 0}px);
+			"
+		/>
+	</span>
+
+	{#if label || description}
+		<span class="switch-content">
+			{#if label}
+				<span class="switch-label">{label}</span>
+			{/if}
+			{#if description}
+				<span class="switch-description">{description}</span>
+			{/if}
+		</span>
+	{/if}
+
+	<input
+		type="checkbox"
+		bind:checked
+		{disabled}
+		class="sr-only"
+		tabindex="-1"
+		aria-hidden="true"
+	/>
+</label>
+
+<style>
+	.dss-switch {
+		display: inline-flex;
+		align-items: flex-start;
+		gap: var(--dss-space-2, 8px);
+		cursor: pointer;
+		font-family: 'Inter', sans-serif;
+		user-select: none;
+	}
+	.dss-switch.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	/* Track */
+	.switch-track {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 9999px;
+		background: var(--ssk-colors-neutral-300, #d1d5db);
+		padding: 2px;
+		flex-shrink: 0;
+		transition: background 0.2s;
+		margin-top: 1px;
+	}
+	.switch-track:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.dss-switch:not(.disabled):hover .switch-track:not(.checked) {
+		background: var(--ssk-colors-neutral-400, #9ca3af);
+	}
+
+	/* Thumb */
+	.switch-thumb {
+		border-radius: 50%;
+		background: white;
+		transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+	}
+
+	/* Content */
+	.switch-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.switch-label {
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.size-sm .switch-label { font-size: 13px; }
+	.size-md .switch-label { font-size: 14px; }
+	.size-lg .switch-label { font-size: 15px; }
+
+	.switch-description {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/svelte/form/Switch.svelte
+++ b/src/lib/svelte/form/Switch.svelte
@@ -47,7 +47,7 @@
 		style="
 			width: {trackWidth}px;
 			height: {trackHeight}px;
-			{checked ? `background: var(--ssk-colors-${color}-500, var(--ssk-colors-primary-500, #32a9ff));` : ''}
+			{checked ? `background: var(--ssk-colors-${color}-500, var(--primary, #32a9ff));` : ''}
 		"
 		on:click={handleToggle}
 		on:keydown={handleKeydown}
@@ -89,7 +89,7 @@
 		align-items: flex-start;
 		gap: var(--dss-space-2, 8px);
 		cursor: pointer;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 		user-select: none;
 	}
 	.dss-switch.disabled {
@@ -153,8 +153,8 @@
 	.size-lg .switch-label { font-size: 15px; }
 
 	.switch-description {
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-caption, 12px);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.4;
 	}
 </style>

--- a/src/lib/svelte/form/Textarea.svelte
+++ b/src/lib/svelte/form/Textarea.svelte
@@ -81,13 +81,13 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-1, 4px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.full-width { width: 100%; }
 
 	/* Label */
 	.dss-textarea-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		line-height: 1.4;
@@ -100,7 +100,7 @@
 	/* Container */
 	.dss-textarea {
 		display: flex;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
 		overflow: hidden;
 	}
@@ -116,7 +116,7 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-default:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -125,17 +125,17 @@
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
 	}
 	.variant-outlined:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
 	.variant-filled {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		border: 1px solid transparent;
 	}
 	.variant-filled:focus-within:not(.disabled) {
 		background: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
 	}
 
@@ -144,7 +144,7 @@
 		border: 1px solid transparent;
 	}
 	.variant-ghost:focus-within:not(.disabled) {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 
 	/* States */
@@ -188,7 +188,7 @@
 		border: none;
 		outline: none;
 		background: transparent;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		font-family: inherit;
 		line-height: 1.5;
 		width: 100%;
@@ -208,9 +208,9 @@
 
 	.dss-textarea-message {
 		margin: 0;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		line-height: 1.4;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 	}
 	.dss-textarea-message.state-error {
 		color: var(--ssk-colors-danger-500, #ef4444);
@@ -223,7 +223,7 @@
 	}
 
 	.char-count {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 		flex-shrink: 0;
 	}

--- a/src/lib/svelte/form/Textarea.svelte
+++ b/src/lib/svelte/form/Textarea.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: string = '';
+	export let label: string = '';
+	export let placeholder: string = '';
+	export let helperText: string = '';
+	export let errorMessage: string = '';
+	export let successMessage: string = '';
+	export let inputSize: 'sm' | 'md' | 'lg' = 'md';
+	export let variant: 'default' | 'outlined' | 'filled' | 'ghost' = 'default';
+	export let state: 'default' | 'error' | 'success' | 'warning' = 'default';
+	export let disabled: boolean = false;
+	export let required: boolean = false;
+	export let fullWidth: boolean = false;
+	export let showCharCount: boolean = false;
+	export let maxLength: number | undefined = undefined;
+	export let rows: number = 3;
+	export let resize: 'none' | 'vertical' | 'both' = 'vertical';
+
+	const dispatch = createEventDispatcher<{
+		input: Event;
+		change: Event;
+		focus: FocusEvent;
+		blur: FocusEvent;
+	}>();
+
+	$: computedState = errorMessage ? 'error' : successMessage ? 'success' : state;
+	$: message = errorMessage || successMessage || helperText;
+	$: charCount = value?.length ?? 0;
+</script>
+
+<div class="dss-textarea-wrapper" class:full-width={fullWidth}>
+	{#if label}
+		<label class="dss-textarea-label">
+			{label}
+			{#if required}
+				<span class="required-mark" aria-hidden="true">*</span>
+			{/if}
+		</label>
+	{/if}
+
+	<div
+		class="dss-textarea size-{inputSize} variant-{variant} state-{computedState}"
+		class:disabled
+	>
+		<textarea
+			bind:value
+			{placeholder}
+			{disabled}
+			{required}
+			{rows}
+			maxlength={maxLength}
+			style="resize: {resize};"
+			aria-invalid={computedState === 'error'}
+			aria-describedby={message ? 'textarea-message' : undefined}
+			on:input={(e) => dispatch('input', e)}
+			on:change={(e) => dispatch('change', e)}
+			on:focus={(e) => dispatch('focus', e)}
+			on:blur={(e) => dispatch('blur', e)}
+		/>
+	</div>
+
+	<div class="dss-textarea-footer">
+		{#if message}
+			<p class="dss-textarea-message state-{computedState}" id="textarea-message">{message}</p>
+		{:else}
+			<span />
+		{/if}
+
+		{#if showCharCount}
+			<span class="char-count" class:at-limit={maxLength != null && charCount >= maxLength}>
+				{charCount}{#if maxLength != null}/{maxLength}{/if}
+			</span>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.dss-textarea-wrapper {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-1, 4px);
+		font-family: 'Inter', sans-serif;
+	}
+	.full-width { width: 100%; }
+
+	/* Label */
+	.dss-textarea-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		line-height: 1.4;
+	}
+	.required-mark {
+		color: var(--ssk-colors-danger-500, #ef4444);
+		margin-left: 2px;
+	}
+
+	/* Container */
+	.dss-textarea {
+		display: flex;
+		border-radius: var(--dss-radius-md, 8px);
+		transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+		overflow: hidden;
+	}
+
+	/* Sizes */
+	.size-sm textarea { font-size: 13px; padding: 6px var(--dss-space-4, 12px); }
+	.size-md textarea { font-size: 14px; padding: 8px var(--dss-space-4, 12px); }
+	.size-lg textarea { font-size: 15px; padding: 10px var(--dss-space-4, 12px); }
+
+	/* Variants */
+	.variant-default {
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-default:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-outlined {
+		background: transparent;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outlined:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-filled {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border: 1px solid transparent;
+	}
+	.variant-filled:focus-within:not(.disabled) {
+		background: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-100, #dbeafe);
+	}
+
+	.variant-ghost {
+		background: transparent;
+		border: 1px solid transparent;
+	}
+	.variant-ghost:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	/* States */
+	.state-error:not(.disabled) {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.state-error:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-danger-500, #ef4444);
+		box-shadow: 0 0 0 2px var(--ssk-colors-danger-50, #fef2f2);
+	}
+
+	.state-success:not(.disabled) {
+		border-color: var(--ssk-colors-success-500, #10b981);
+	}
+	.state-success:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-success-500, #10b981);
+		box-shadow: 0 0 0 2px var(--ssk-colors-success-50, #ecfdf5);
+	}
+
+	.state-warning:not(.disabled) {
+		border-color: var(--ssk-colors-warning-500, #f59e0b);
+	}
+	.state-warning:focus-within:not(.disabled) {
+		border-color: var(--ssk-colors-warning-500, #f59e0b);
+		box-shadow: 0 0 0 2px var(--ssk-colors-warning-50, #fffbeb);
+	}
+
+	/* Disabled */
+	.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		background: var(--dss-bg-disabled, #f9fafb);
+	}
+	.disabled textarea {
+		cursor: not-allowed;
+	}
+
+	/* Textarea element */
+	.dss-textarea textarea {
+		flex: 1;
+		border: none;
+		outline: none;
+		background: transparent;
+		color: var(--ssk-colors-text-900, #111827);
+		font-family: inherit;
+		line-height: 1.5;
+		width: 100%;
+		min-width: 0;
+	}
+	.dss-textarea textarea::placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	/* Footer */
+	.dss-textarea-footer {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: var(--dss-space-4, 12px);
+	}
+
+	.dss-textarea-message {
+		margin: 0;
+		font-size: var(--dss-font-caption, 12px);
+		line-height: 1.4;
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+	.dss-textarea-message.state-error {
+		color: var(--ssk-colors-danger-500, #ef4444);
+	}
+	.dss-textarea-message.state-success {
+		color: var(--ssk-colors-success-500, #10b981);
+	}
+	.dss-textarea-message.state-warning {
+		color: var(--ssk-colors-warning-500, #f59e0b);
+	}
+
+	.char-count {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		flex-shrink: 0;
+	}
+	.char-count.at-limit {
+		color: var(--ssk-colors-danger-500, #ef4444);
+	}
+</style>

--- a/src/lib/svelte/index.ts
+++ b/src/lib/svelte/index.ts
@@ -8,6 +8,16 @@ export { default as Badge } from './ui/Badge.svelte';
 export { default as Divider } from './ui/Divider.svelte';
 export { default as Logo } from './ui/Logo.svelte';
 export { default as Spinner } from './ui/Spinner.svelte';
+export { default as Accordion } from './ui/Accordion.svelte';
+export { default as NumberInput } from './ui/NumberInput.svelte';
+export { default as Tag } from './ui/Tag.svelte';
+export { default as TagInput } from './ui/TagInput.svelte';
+export { default as ProgressBar } from './ui/ProgressBar.svelte';
+export { default as Rating } from './ui/Rating.svelte';
+export { default as ImagePreview } from './ui/ImagePreview.svelte';
+export { default as AvatarGroup } from './ui/AvatarGroup.svelte';
+export { default as ButtonGroup } from './ui/ButtonGroup.svelte';
+export { default as IconButton } from './ui/IconButton.svelte';
 
 // Layout Components
 export { default as TopNavbar } from './layout/TopNavbar.svelte';
@@ -16,9 +26,58 @@ export { default as SidebarHeader } from './layout/SidebarHeader.svelte';
 export { default as SidebarList } from './layout/SidebarList.svelte';
 export { default as SidebarGroup } from './layout/SidebarGroup.svelte';
 export { default as SidebarItem } from './layout/SidebarItem.svelte';
+export { default as PageHeader } from './layout/PageHeader.svelte';
+export { default as Card } from './layout/Card.svelte';
+export { default as CardHeader } from './layout/CardHeader.svelte';
+export { default as CardBody } from './layout/CardBody.svelte';
+export { default as CardFooter } from './layout/CardFooter.svelte';
+
+// Navigation Components
+export { default as Breadcrumb } from './navigation/Breadcrumb.svelte';
+export { default as Tabs } from './navigation/Tabs.svelte';
+export { default as Stepper } from './navigation/Stepper.svelte';
+export { default as Timeline } from './navigation/Timeline.svelte';
+
+// Form Components
+export { default as Input } from './form/Input.svelte';
+export { default as Textarea } from './form/Textarea.svelte';
+export { default as Checkbox } from './form/Checkbox.svelte';
+export { default as CheckboxGroup } from './form/CheckboxGroup.svelte';
+export { default as Radio } from './form/Radio.svelte';
+export { default as RadioGroup } from './form/RadioGroup.svelte';
+export { default as Switch } from './form/Switch.svelte';
+export { default as FormField } from './form/FormField.svelte';
+export { default as FormError } from './form/FormError.svelte';
+export { default as FormLabel } from './form/FormLabel.svelte';
+export { default as FormHelperText } from './form/FormHelperText.svelte';
+export { default as SearchField } from './form/SearchField.svelte';
+export { default as DatePicker } from './form/DatePicker.svelte';
+export { default as FileUpload } from './form/FileUpload.svelte';
+export { default as ColorPicker } from './form/ColorPicker.svelte';
+export { default as OTPInput } from './form/OTPInput.svelte';
+
+// Feedback Components
+export { default as Alert } from './feedback/Alert.svelte';
+export { default as NotificationCenter } from './feedback/NotificationCenter.svelte';
 
 // Overlay Components
 export { default as Dropdown } from './overlay/Dropdown.svelte';
 export { default as DropdownOption } from './overlay/DropdownOption.svelte';
 export { default as Modal } from './overlay/Modal.svelte';
 export { default as ToastContainer } from './overlay/ToastContainer.svelte';
+export { default as Tooltip } from './overlay/Tooltip.svelte';
+export { default as Popover } from './overlay/Popover.svelte';
+export { default as ConfirmDialog } from './overlay/ConfirmDialog.svelte';
+export { default as Drawer } from './overlay/Drawer.svelte';
+export { default as Menu } from './overlay/Menu.svelte';
+
+// Data Components
+export { default as Table } from './data/Table.svelte';
+export { default as AdvancedDataTable } from './data/AdvancedDataTable.svelte';
+export { default as Pagination } from './data/Pagination.svelte';
+export { default as EmptyState } from './data/EmptyState.svelte';
+export { default as Skeleton } from './data/Skeleton.svelte';
+export { default as SkeletonCard } from './data/SkeletonCard.svelte';
+export { default as SkeletonList } from './data/SkeletonList.svelte';
+export { default as SkeletonTable } from './data/SkeletonTable.svelte';
+export { default as FilterBar } from './data/FilterBar.svelte';

--- a/src/lib/svelte/index.ts
+++ b/src/lib/svelte/index.ts
@@ -1,0 +1,24 @@
+// UI Components
+export { default as Icon } from './ui/Icon.svelte';
+export { default as Text } from './ui/Text.svelte';
+export { default as Heading } from './ui/Heading.svelte';
+export { default as Button } from './ui/Button.svelte';
+export { default as Avatar } from './ui/Avatar.svelte';
+export { default as Badge } from './ui/Badge.svelte';
+export { default as Divider } from './ui/Divider.svelte';
+export { default as Logo } from './ui/Logo.svelte';
+export { default as Spinner } from './ui/Spinner.svelte';
+
+// Layout Components
+export { default as TopNavbar } from './layout/TopNavbar.svelte';
+export { default as Sidebar } from './layout/Sidebar.svelte';
+export { default as SidebarHeader } from './layout/SidebarHeader.svelte';
+export { default as SidebarList } from './layout/SidebarList.svelte';
+export { default as SidebarGroup } from './layout/SidebarGroup.svelte';
+export { default as SidebarItem } from './layout/SidebarItem.svelte';
+
+// Overlay Components
+export { default as Dropdown } from './overlay/Dropdown.svelte';
+export { default as DropdownOption } from './overlay/DropdownOption.svelte';
+export { default as Modal } from './overlay/Modal.svelte';
+export { default as ToastContainer } from './overlay/ToastContainer.svelte';

--- a/src/lib/svelte/layout/Card.svelte
+++ b/src/lib/svelte/layout/Card.svelte
@@ -10,8 +10,8 @@
 <style>
 	.dss-card {
 		background: var(--dss-bg-primary, #ffffff);
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-lg, 12px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-lg, 12px);
 		overflow: hidden;
 		transition: box-shadow 0.2s ease;
 	}

--- a/src/lib/svelte/layout/Card.svelte
+++ b/src/lib/svelte/layout/Card.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	export let hover: boolean = false;
+	export let elevation: 'none' | 'sm' | 'md' | 'lg' = 'sm';
+</script>
+
+<div class="dss-card elevation-{elevation}" class:hoverable={hover}>
+	<slot />
+</div>
+
+<style>
+	.dss-card {
+		background: var(--dss-bg-primary, #ffffff);
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-lg, 12px);
+		overflow: hidden;
+		transition: box-shadow 0.2s ease;
+	}
+
+	/* Elevation */
+	.elevation-none { box-shadow: none; }
+	.elevation-sm { box-shadow: var(--dss-shadow-sm, 0 1px 2px rgba(0,0,0,0.05)); }
+	.elevation-md { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); }
+	.elevation-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); }
+
+	/* Hover */
+	.hoverable {
+		cursor: pointer;
+	}
+	.hoverable:hover {
+		box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+	}
+	.hoverable.elevation-sm:hover {
+		box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+	}
+	.hoverable.elevation-md:hover {
+		box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
+	}
+	.hoverable.elevation-lg:hover {
+		box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1);
+	}
+</style>

--- a/src/lib/svelte/layout/CardBody.svelte
+++ b/src/lib/svelte/layout/CardBody.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	/* CardBody — padding wrapper for card content */
+</script>
+
+<div class="dss-card-body">
+	<slot />
+</div>
+
+<style>
+	.dss-card-body {
+		padding: var(--dss-space-16, 16px);
+	}
+</style>

--- a/src/lib/svelte/layout/CardFooter.svelte
+++ b/src/lib/svelte/layout/CardFooter.svelte
@@ -12,6 +12,6 @@
 		align-items: center;
 		gap: var(--dss-space-12, 12px);
 		padding: var(--dss-space-16, 16px);
-		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-top: 1px solid var(--border, #e5e7eb);
 	}
 </style>

--- a/src/lib/svelte/layout/CardFooter.svelte
+++ b/src/lib/svelte/layout/CardFooter.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	/* CardFooter — bottom section with flex row layout */
+</script>
+
+<div class="dss-card-footer">
+	<slot />
+</div>
+
+<style>
+	.dss-card-footer {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-12, 12px);
+		padding: var(--dss-space-16, 16px);
+		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+</style>

--- a/src/lib/svelte/layout/CardHeader.svelte
+++ b/src/lib/svelte/layout/CardHeader.svelte
@@ -18,7 +18,7 @@
 		justify-content: space-between;
 		gap: var(--dss-space-12, 12px);
 		padding: var(--dss-space-16, 16px);
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.card-header-content {

--- a/src/lib/svelte/layout/CardHeader.svelte
+++ b/src/lib/svelte/layout/CardHeader.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	/* CardHeader — title area with optional action slot */
+</script>
+
+<div class="dss-card-header">
+	<div class="card-header-content">
+		<slot />
+	</div>
+	<div class="card-header-action">
+		<slot name="action" />
+	</div>
+</div>
+
+<style>
+	.dss-card-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--dss-space-12, 12px);
+		padding: var(--dss-space-16, 16px);
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.card-header-content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+		min-width: 0;
+		flex: 1;
+	}
+
+	.card-header-action {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		flex-shrink: 0;
+	}
+</style>

--- a/src/lib/svelte/layout/PageHeader.svelte
+++ b/src/lib/svelte/layout/PageHeader.svelte
@@ -29,7 +29,7 @@
 		gap: var(--dss-space-8, 8px);
 		padding: var(--dss-space-16, 16px) var(--dss-space-24, 24px);
 		background: var(--dss-bg-primary, #ffffff);
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.dss-page-header.sticky {
@@ -54,16 +54,16 @@
 
 	.header-title {
 		margin: 0;
-		font-size: var(--dss-font-h2, 20px);
+		font-size: var(--text-h2, 20px);
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		line-height: 1.3;
 	}
 
 	.header-subtitle {
 		margin: 0;
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-p, 14px);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.4;
 	}
 

--- a/src/lib/svelte/layout/PageHeader.svelte
+++ b/src/lib/svelte/layout/PageHeader.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	export let title: string;
+	export let subtitle: string | undefined = undefined;
+	export let sticky: boolean = false;
+</script>
+
+<header class="dss-page-header" class:sticky>
+	<slot name="breadcrumb" />
+
+	<div class="header-main">
+		<div class="header-title-group">
+			<h1 class="header-title">{title}</h1>
+			{#if subtitle}
+				<p class="header-subtitle">{subtitle}</p>
+			{/if}
+		</div>
+		<div class="header-actions">
+			<slot name="actions" />
+		</div>
+	</div>
+
+	<slot name="tabs" />
+</header>
+
+<style>
+	.dss-page-header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-8, 8px);
+		padding: var(--dss-space-16, 16px) var(--dss-space-24, 24px);
+		background: var(--dss-bg-primary, #ffffff);
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.dss-page-header.sticky {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+	}
+
+	.header-main {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--dss-space-16, 16px);
+	}
+
+	.header-title-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+		min-width: 0;
+	}
+
+	.header-title {
+		margin: 0;
+		font-size: var(--dss-font-h2, 20px);
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+		line-height: 1.3;
+	}
+
+	.header-subtitle {
+		margin: 0;
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.4;
+	}
+
+	.header-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		flex-shrink: 0;
+	}
+</style>

--- a/src/lib/svelte/layout/Sidebar.svelte
+++ b/src/lib/svelte/layout/Sidebar.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let expanded: boolean = true;
+	export let expandedGroups: string[] = [];
+
+	const dispatch = createEventDispatcher();
+
+	function handleExpandedGroupsChanged(key: string, isExpanded: boolean) {
+		dispatch('expanded-groups-changed', { key, expanded: isExpanded });
+	}
+
+	// Expose for child groups to call
+	export { handleExpandedGroupsChanged };
+</script>
+
+<aside class="dss-sidebar" class:collapsed={!expanded}>
+	<div class="sidebar-header">
+		<slot name="header" />
+	</div>
+	<div class="sidebar-body">
+		<slot />
+	</div>
+	<div class="sidebar-footer">
+		<slot name="footer" />
+	</div>
+</aside>
+
+<style>
+	.dss-sidebar {
+		display: flex;
+		flex-direction: column;
+		width: 260px;
+		height: 100%;
+		background: white;
+		border-right: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		transition: width 0.2s;
+		overflow: hidden;
+		box-sizing: border-box;
+	}
+
+	.dss-sidebar.collapsed {
+		width: 64px;
+	}
+
+	.sidebar-header {
+		flex-shrink: 0;
+	}
+
+	.sidebar-body {
+		flex: 1;
+		overflow-y: auto;
+	}
+
+	.sidebar-footer {
+		flex-shrink: 0;
+		padding: 8px;
+		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.sidebar-footer:empty {
+		display: none;
+	}
+</style>

--- a/src/lib/svelte/layout/Sidebar.svelte
+++ b/src/lib/svelte/layout/Sidebar.svelte
@@ -33,7 +33,7 @@
 		width: 260px;
 		height: 100%;
 		background: white;
-		border-right: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-right: 1px solid var(--border, #e5e7eb);
 		transition: width 0.2s;
 		overflow: hidden;
 		box-sizing: border-box;
@@ -55,7 +55,7 @@
 	.sidebar-footer {
 		flex-shrink: 0;
 		padding: 8px;
-		border-top: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-top: 1px solid var(--border, #e5e7eb);
 	}
 
 	.sidebar-footer:empty {

--- a/src/lib/svelte/layout/SidebarGroup.svelte
+++ b/src/lib/svelte/layout/SidebarGroup.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	export let label: string = '';
+	export let key: string = '';
+	export let expanded: boolean = true;
+
+	function toggle() {
+		expanded = !expanded;
+	}
+</script>
+
+<div class="dss-sidebar-group" data-key={key}>
+	<button class="group-header" on:click={toggle} type="button">
+		<span class="group-label">{label}</span>
+		<span class="group-chevron" class:expanded>
+			<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+				<path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+			</svg>
+		</span>
+	</button>
+
+	{#if expanded}
+		<div class="group-items">
+			<slot />
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-sidebar-group {
+		margin-bottom: 4px;
+	}
+
+	.group-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--ssk-colors-neutral-400, #9ca3af);
+		font-family: inherit;
+	}
+
+	.group-header:hover {
+		color: var(--ssk-colors-neutral-600, #4b5563);
+	}
+
+	.group-chevron {
+		display: inline-flex;
+		transition: transform 0.2s;
+		transform: rotate(-90deg);
+	}
+
+	.group-chevron.expanded {
+		transform: rotate(0deg);
+	}
+
+	.group-items {
+		padding: 0 4px 4px;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+</style>

--- a/src/lib/svelte/layout/SidebarHeader.svelte
+++ b/src/lib/svelte/layout/SidebarHeader.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	export let expanded: boolean = true;
+</script>
+
+<div class="dss-sidebar-header">
+	{#if expanded}
+		<slot />
+	{:else}
+		<slot name="mini" />
+	{/if}
+</div>
+
+<style>
+	.dss-sidebar-header {
+		padding: 12px;
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+</style>

--- a/src/lib/svelte/layout/SidebarHeader.svelte
+++ b/src/lib/svelte/layout/SidebarHeader.svelte
@@ -13,6 +13,6 @@
 <style>
 	.dss-sidebar-header {
 		padding: 12px;
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 </style>

--- a/src/lib/svelte/layout/SidebarItem.svelte
+++ b/src/lib/svelte/layout/SidebarItem.svelte
@@ -14,7 +14,7 @@
 		align-items: center;
 		gap: 10px;
 		padding: 8px 12px;
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		cursor: pointer;
 		transition: background 0.15s, color 0.15s;
 		font-size: 14px;
@@ -22,7 +22,7 @@
 	}
 
 	.dss-sidebar-item:hover {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 
 	.dss-sidebar-item.actived {

--- a/src/lib/svelte/layout/SidebarItem.svelte
+++ b/src/lib/svelte/layout/SidebarItem.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	export let actived: boolean = false;
+	export let key: string = '';
+</script>
+
+<div class="dss-sidebar-item" class:actived data-key={key}>
+	<span class="item-prefix"><slot name="prefix" /></span>
+	<span class="item-label"><slot /></span>
+</div>
+
+<style>
+	.dss-sidebar-item {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 8px 12px;
+		border-radius: var(--dss-radius-sm, 6px);
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+		font-size: 14px;
+		color: var(--ssk-colors-neutral-700, #374151);
+	}
+
+	.dss-sidebar-item:hover {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	.dss-sidebar-item.actived {
+		background: var(--ssk-colors-primary-50, #f0f9ff);
+		color: var(--ssk-colors-primary-600, #1b8bf5);
+		font-weight: 500;
+	}
+
+	.item-prefix {
+		display: inline-flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
+	.item-prefix:empty { display: none; }
+
+	.item-label {
+		flex: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+</style>

--- a/src/lib/svelte/layout/SidebarList.svelte
+++ b/src/lib/svelte/layout/SidebarList.svelte
@@ -1,0 +1,11 @@
+<div class="dss-sidebar-list">
+	<slot />
+</div>
+
+<style>
+	.dss-sidebar-list {
+		flex: 1;
+		overflow-y: auto;
+		padding: 8px;
+	}
+</style>

--- a/src/lib/svelte/layout/TopNavbar.svelte
+++ b/src/lib/svelte/layout/TopNavbar.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	/* TopNavbar — horizontal header bar with left/right slots */
+</script>
+
+<nav class="dss-top-navbar">
+	<div class="navbar-left">
+		<slot name="left" />
+	</div>
+	<div class="navbar-right">
+		<slot name="right" />
+	</div>
+</nav>
+
+<style>
+	.dss-top-navbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 16px;
+		height: 56px;
+		background: white;
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		box-sizing: border-box;
+	}
+
+	.navbar-left,
+	.navbar-right {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+</style>

--- a/src/lib/svelte/layout/TopNavbar.svelte
+++ b/src/lib/svelte/layout/TopNavbar.svelte
@@ -19,7 +19,7 @@
 		padding: 0 16px;
 		height: 56px;
 		background: white;
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 		box-sizing: border-box;
 	}
 

--- a/src/lib/svelte/navigation/Breadcrumb.svelte
+++ b/src/lib/svelte/navigation/Breadcrumb.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let items: { label: string; href?: string; icon?: string }[] = [];
+	export let separator: 'chevron' | 'slash' | 'dot' = 'chevron';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let maxItems: number | undefined = undefined;
+
+	const dispatch = createEventDispatcher<{ navigate: { label: string; href?: string; icon?: string } }>();
+
+	$: visibleItems = (() => {
+		if (!maxItems || items.length <= maxItems) return items;
+		const head = items.slice(0, 1);
+		const tail = items.slice(-(maxItems - 2));
+		return [...head, { label: '\u2026' }, ...tail];
+	})();
+
+	function handleClick(item: { label: string; href?: string; icon?: string }, index: number) {
+		if (index < visibleItems.length - 1 && item.href) {
+			dispatch('navigate', item);
+		}
+	}
+</script>
+
+<nav class="dss-breadcrumb size-{size}" aria-label="Breadcrumb">
+	<ol class="breadcrumb-list">
+		{#each visibleItems as item, i}
+			<li class="breadcrumb-item">
+				{#if i < visibleItems.length - 1 && item.label !== '\u2026'}
+					<a
+						href={item.href || '#'}
+						class="breadcrumb-link"
+						on:click|preventDefault={() => handleClick(item, i)}
+					>
+						{#if item.icon}
+							<span class="breadcrumb-icon">{item.icon}</span>
+						{/if}
+						{item.label}
+					</a>
+				{:else if item.label === '\u2026'}
+					<span class="breadcrumb-ellipsis">&hellip;</span>
+				{:else}
+					<span class="breadcrumb-current" aria-current="page">
+						{#if item.icon}
+							<span class="breadcrumb-icon">{item.icon}</span>
+						{/if}
+						{item.label}
+					</span>
+				{/if}
+			</li>
+			{#if i < visibleItems.length - 1}
+				<li class="breadcrumb-separator" aria-hidden="true">
+					{#if separator === 'chevron'}
+						<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+							<path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+						</svg>
+					{:else if separator === 'slash'}
+						<span>/</span>
+					{:else}
+						<span>&middot;</span>
+					{/if}
+				</li>
+			{/if}
+		{/each}
+	</ol>
+</nav>
+
+<style>
+	.dss-breadcrumb {
+		display: flex;
+		align-items: center;
+	}
+
+	.breadcrumb-list {
+		display: flex;
+		align-items: center;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		gap: var(--dss-space-4, 4px);
+	}
+
+	.breadcrumb-item {
+		display: flex;
+		align-items: center;
+	}
+
+	.breadcrumb-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		text-decoration: none;
+		transition: color 0.15s ease;
+	}
+
+	.breadcrumb-link:hover {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		text-decoration: underline;
+	}
+
+	.breadcrumb-current {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		color: var(--ssk-colors-text-900, #111827);
+		font-weight: 500;
+	}
+
+	.breadcrumb-ellipsis {
+		color: var(--ssk-colors-text-400, #9ca3af);
+		padding: 0 var(--dss-space-4, 4px);
+	}
+
+	.breadcrumb-separator {
+		display: flex;
+		align-items: center;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.breadcrumb-icon {
+		display: inline-flex;
+		align-items: center;
+	}
+
+	/* Sizes */
+	.size-sm { font-size: var(--dss-font-caption, 12px); }
+	.size-md { font-size: var(--dss-font-sm, 13px); }
+	.size-lg { font-size: var(--dss-font-body, 14px); }
+
+	.size-sm .breadcrumb-separator svg { width: 12px; height: 12px; }
+	.size-md .breadcrumb-separator svg { width: 16px; height: 16px; }
+	.size-lg .breadcrumb-separator svg { width: 18px; height: 18px; }
+</style>

--- a/src/lib/svelte/navigation/Breadcrumb.svelte
+++ b/src/lib/svelte/navigation/Breadcrumb.svelte
@@ -89,13 +89,13 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--dss-space-4, 4px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		text-decoration: none;
 		transition: color 0.15s ease;
 	}
 
 	.breadcrumb-link:hover {
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 		text-decoration: underline;
 	}
 
@@ -103,7 +103,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--dss-space-4, 4px);
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		font-weight: 500;
 	}
 
@@ -124,9 +124,9 @@
 	}
 
 	/* Sizes */
-	.size-sm { font-size: var(--dss-font-caption, 12px); }
-	.size-md { font-size: var(--dss-font-sm, 13px); }
-	.size-lg { font-size: var(--dss-font-body, 14px); }
+	.size-sm { font-size: var(--text-caption, 12px); }
+	.size-md { font-size: var(--text-sm, 13px); }
+	.size-lg { font-size: var(--text-p, 14px); }
 
 	.size-sm .breadcrumb-separator svg { width: 12px; height: 12px; }
 	.size-md .breadcrumb-separator svg { width: 16px; height: 16px; }

--- a/src/lib/svelte/navigation/Stepper.svelte
+++ b/src/lib/svelte/navigation/Stepper.svelte
@@ -77,10 +77,10 @@
 		left: calc(50% + 18px);
 		right: calc(-50% + 18px);
 		height: 2px;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 	.orientation-horizontal .dss-stepper-connector.filled {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 	}
 	.orientation-horizontal .dss-stepper-content {
 		margin-top: var(--dss-space-8, 8px);
@@ -107,10 +107,10 @@
 		left: 15px;
 		width: 2px;
 		bottom: 0;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 	.orientation-vertical .dss-stepper-connector.filled {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 	}
 	.orientation-vertical .dss-stepper-content {
 		margin-left: var(--dss-space-12, 12px);
@@ -131,8 +131,8 @@
 		justify-content: center;
 		width: 32px;
 		height: 32px;
-		border-radius: var(--dss-radius-full, 9999px);
-		font-size: var(--dss-font-sm, 13px);
+		border-radius: var(--radius-full, 9999px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 600;
 		transition: background 0.2s, border-color 0.2s, color 0.2s;
 		flex-shrink: 0;
@@ -140,19 +140,19 @@
 
 	/* States */
 	.completed .dss-stepper-circle {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
-		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		border: 2px solid var(--primary, #32a9ff);
 	}
 	.active .dss-stepper-circle {
 		background: white;
-		color: var(--ssk-colors-primary-500, #32a9ff);
-		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
+		border: 2px solid var(--primary, #32a9ff);
 	}
 	.upcoming .dss-stepper-circle {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-400, #9ca3af);
-		border: 2px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border: 2px solid var(--border, #e5e7eb);
 	}
 
 	.dss-stepper-content {
@@ -161,7 +161,7 @@
 	}
 
 	.dss-stepper-label {
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
@@ -173,7 +173,7 @@
 	}
 
 	.dss-stepper-description {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 		margin-top: 2px;
 	}

--- a/src/lib/svelte/navigation/Stepper.svelte
+++ b/src/lib/svelte/navigation/Stepper.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let steps: { label: string; description?: string }[] = [];
+	export let current: number = 0;
+	export let orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+	const dispatch = createEventDispatcher();
+
+	function handleStepClick(index: number) {
+		dispatch('stepClick', index);
+	}
+
+	function handleKeydown(e: KeyboardEvent, index: number) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			handleStepClick(index);
+		}
+	}
+</script>
+
+<div class="dss-stepper orientation-{orientation}" role="list">
+	{#each steps as step, i}
+		<div class="dss-stepper-item" class:completed={i < current} class:active={i === current} class:upcoming={i > current} role="listitem">
+			<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+			<div
+				class="dss-stepper-indicator"
+				on:click={() => handleStepClick(i)}
+				on:keydown={(e) => handleKeydown(e, i)}
+				tabindex="0"
+				role="button"
+				aria-label="Step {i + 1}: {step.label}"
+			>
+				<span class="dss-stepper-circle">
+					{#if i < current}
+						<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+							<path d="M3 7l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+						</svg>
+					{:else}
+						{i + 1}
+					{/if}
+				</span>
+			</div>
+			{#if i < steps.length - 1}
+				<div class="dss-stepper-connector" class:filled={i < current} />
+			{/if}
+			<div class="dss-stepper-content">
+				<span class="dss-stepper-label">{step.label}</span>
+				{#if step.description}
+					<span class="dss-stepper-description">{step.description}</span>
+				{/if}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-stepper {
+		display: flex;
+	}
+
+	/* Horizontal */
+	.orientation-horizontal {
+		flex-direction: row;
+		align-items: flex-start;
+	}
+	.orientation-horizontal .dss-stepper-item {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		flex: 1;
+		position: relative;
+	}
+	.orientation-horizontal .dss-stepper-connector {
+		position: absolute;
+		top: 16px;
+		left: calc(50% + 18px);
+		right: calc(-50% + 18px);
+		height: 2px;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.orientation-horizontal .dss-stepper-connector.filled {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.orientation-horizontal .dss-stepper-content {
+		margin-top: var(--dss-space-8, 8px);
+		text-align: center;
+	}
+
+	/* Vertical */
+	.orientation-vertical {
+		flex-direction: column;
+	}
+	.orientation-vertical .dss-stepper-item {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		position: relative;
+		padding-bottom: var(--dss-space-24, 24px);
+	}
+	.orientation-vertical .dss-stepper-item:last-child {
+		padding-bottom: 0;
+	}
+	.orientation-vertical .dss-stepper-connector {
+		position: absolute;
+		top: 36px;
+		left: 15px;
+		width: 2px;
+		bottom: 0;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.orientation-vertical .dss-stepper-connector.filled {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.orientation-vertical .dss-stepper-content {
+		margin-left: var(--dss-space-12, 12px);
+		padding-top: 4px;
+	}
+
+	.dss-stepper-indicator {
+		cursor: pointer;
+		outline: none;
+	}
+	.dss-stepper-indicator:focus-visible .dss-stepper-circle {
+		box-shadow: 0 0 0 3px var(--ssk-colors-primary-50, #eff8ff);
+	}
+
+	.dss-stepper-circle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--dss-radius-full, 9999px);
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 600;
+		transition: background 0.2s, border-color 0.2s, color 0.2s;
+		flex-shrink: 0;
+	}
+
+	/* States */
+	.completed .dss-stepper-circle {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.active .dss-stepper-circle {
+		background: white;
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.upcoming .dss-stepper-circle {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		border: 2px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.dss-stepper-content {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dss-stepper-label {
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.active .dss-stepper-label {
+		color: var(--ssk-colors-primary-700, #0b6bcb);
+	}
+	.upcoming .dss-stepper-label {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.dss-stepper-description {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		margin-top: 2px;
+	}
+</style>

--- a/src/lib/svelte/navigation/Tabs.svelte
+++ b/src/lib/svelte/navigation/Tabs.svelte
@@ -59,7 +59,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0;
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.full-width .tabs-list {
@@ -79,7 +79,7 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		font-weight: 500;
 		white-space: nowrap;
 		position: relative;
@@ -97,7 +97,7 @@
 
 	/* Default variant — bottom border indicator */
 	.variant-default .tab-item.active {
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 	}
 
 	.variant-default .tab-item.active::after {
@@ -107,44 +107,44 @@
 		left: 0;
 		right: 0;
 		height: 2px;
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		border-radius: 1px 1px 0 0;
 	}
 
 	/* Outlined variant — bordered tabs */
 	.variant-outlined .tabs-list {
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 
 	.variant-outlined .tab-item {
 		border: 1px solid transparent;
 		border-bottom: none;
-		border-radius: var(--dss-radius-sm, 4px) var(--dss-radius-sm, 4px) 0 0;
+		border-radius: var(--radius-sm, 4px) var(--radius-sm, 4px) 0 0;
 		margin-bottom: -1px;
 	}
 
 	.variant-outlined .tab-item.active {
-		color: var(--ssk-colors-primary-500, #32a9ff);
-		border-color: var(--ssk-colors-neutral-200, #e5e7eb);
+		color: var(--primary, #32a9ff);
+		border-color: var(--border, #e5e7eb);
 		background: var(--dss-bg-primary, #ffffff);
 	}
 
 	/* Filled variant — background on active */
 	.variant-filled .tabs-list {
 		border-bottom: none;
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
-		border-radius: var(--dss-radius-md, 8px);
+		background: var(--muted, #f3f4f6);
+		border-radius: var(--radius-md, 8px);
 		padding: 3px;
 		gap: 2px;
 	}
 
 	.variant-filled .tab-item {
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 	}
 
 	.variant-filled .tab-item.active {
 		background: var(--dss-bg-primary, #ffffff);
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		box-shadow: var(--dss-shadow-sm, 0 1px 2px rgba(0,0,0,0.05));
 	}
 
@@ -156,8 +156,8 @@
 		padding: 0 6px;
 		min-width: 18px;
 		height: 18px;
-		border-radius: var(--dss-radius-full, 9999px);
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--radius-full, 9999px);
+		background: var(--border, #e5e7eb);
 		color: var(--ssk-colors-text-700, #374151);
 		font-size: 11px;
 		font-weight: 600;
@@ -165,7 +165,7 @@
 
 	.tab-item.active .tab-badge {
 		background: var(--ssk-colors-primary-50, #eff8ff);
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 	}
 
 	.tab-icon {
@@ -176,15 +176,15 @@
 	/* Sizes */
 	.size-sm .tab-item {
 		padding: var(--dss-space-4, 4px) var(--dss-space-12, 12px);
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 	}
 	.size-md .tab-item {
 		padding: var(--dss-space-8, 8px) var(--dss-space-16, 16px);
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 	}
 	.size-lg .tab-item {
 		padding: var(--dss-space-12, 12px) var(--dss-space-20, 20px);
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 	}
 
 	.tabs-content {

--- a/src/lib/svelte/navigation/Tabs.svelte
+++ b/src/lib/svelte/navigation/Tabs.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let tabs: { id: string; label: string; icon?: string; disabled?: boolean; badge?: string }[] = [];
+	export let variant: 'default' | 'outlined' | 'filled' = 'default';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let activeTab: string | undefined = undefined;
+	export let fullWidth: boolean = false;
+
+	const dispatch = createEventDispatcher<{ change: string }>();
+
+	$: if (!activeTab && tabs.length > 0) {
+		activeTab = tabs[0].id;
+	}
+
+	function handleTabClick(tab: { id: string; disabled?: boolean }) {
+		if (tab.disabled) return;
+		activeTab = tab.id;
+		dispatch('change', tab.id);
+	}
+</script>
+
+<div class="dss-tabs variant-{variant} size-{size}" class:full-width={fullWidth}>
+	<div class="tabs-list" role="tablist">
+		{#each tabs as tab (tab.id)}
+			<button
+				class="tab-item"
+				class:active={activeTab === tab.id}
+				class:disabled={tab.disabled}
+				role="tab"
+				aria-selected={activeTab === tab.id}
+				aria-disabled={tab.disabled || false}
+				tabindex={tab.disabled ? -1 : 0}
+				on:click={() => handleTabClick(tab)}
+			>
+				{#if tab.icon}
+					<span class="tab-icon">{tab.icon}</span>
+				{/if}
+				<span class="tab-label">{tab.label}</span>
+				{#if tab.badge}
+					<span class="tab-badge">{tab.badge}</span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+	<div class="tabs-content">
+		<slot />
+	</div>
+</div>
+
+<style>
+	.dss-tabs {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+	}
+
+	.tabs-list {
+		display: flex;
+		align-items: center;
+		gap: 0;
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.full-width .tabs-list {
+		width: 100%;
+	}
+
+	.full-width .tab-item {
+		flex: 1;
+		justify-content: center;
+	}
+
+	.tab-item {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		padding: var(--dss-space-8, 8px) var(--dss-space-16, 16px);
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--ssk-colors-text-500, #6b7280);
+		font-weight: 500;
+		white-space: nowrap;
+		position: relative;
+		transition: color 0.15s ease, background 0.15s ease;
+	}
+
+	.tab-item:hover:not(.disabled) {
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.tab-item.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	/* Default variant — bottom border indicator */
+	.variant-default .tab-item.active {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.variant-default .tab-item.active::after {
+		content: '';
+		position: absolute;
+		bottom: -1px;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		border-radius: 1px 1px 0 0;
+	}
+
+	/* Outlined variant — bordered tabs */
+	.variant-outlined .tabs-list {
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.variant-outlined .tab-item {
+		border: 1px solid transparent;
+		border-bottom: none;
+		border-radius: var(--dss-radius-sm, 4px) var(--dss-radius-sm, 4px) 0 0;
+		margin-bottom: -1px;
+	}
+
+	.variant-outlined .tab-item.active {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--dss-bg-primary, #ffffff);
+	}
+
+	/* Filled variant — background on active */
+	.variant-filled .tabs-list {
+		border-bottom: none;
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border-radius: var(--dss-radius-md, 8px);
+		padding: 3px;
+		gap: 2px;
+	}
+
+	.variant-filled .tab-item {
+		border-radius: var(--dss-radius-sm, 4px);
+	}
+
+	.variant-filled .tab-item.active {
+		background: var(--dss-bg-primary, #ffffff);
+		color: var(--ssk-colors-text-900, #111827);
+		box-shadow: var(--dss-shadow-sm, 0 1px 2px rgba(0,0,0,0.05));
+	}
+
+	/* Tab badge */
+	.tab-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0 6px;
+		min-width: 18px;
+		height: 18px;
+		border-radius: var(--dss-radius-full, 9999px);
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		color: var(--ssk-colors-text-700, #374151);
+		font-size: 11px;
+		font-weight: 600;
+	}
+
+	.tab-item.active .tab-badge {
+		background: var(--ssk-colors-primary-50, #eff8ff);
+		color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.tab-icon {
+		display: inline-flex;
+		align-items: center;
+	}
+
+	/* Sizes */
+	.size-sm .tab-item {
+		padding: var(--dss-space-4, 4px) var(--dss-space-12, 12px);
+		font-size: var(--dss-font-caption, 12px);
+	}
+	.size-md .tab-item {
+		padding: var(--dss-space-8, 8px) var(--dss-space-16, 16px);
+		font-size: var(--dss-font-sm, 13px);
+	}
+	.size-lg .tab-item {
+		padding: var(--dss-space-12, 12px) var(--dss-space-20, 20px);
+		font-size: var(--dss-font-body, 14px);
+	}
+
+	.tabs-content {
+		padding-top: var(--dss-space-16, 16px);
+	}
+</style>

--- a/src/lib/svelte/navigation/Timeline.svelte
+++ b/src/lib/svelte/navigation/Timeline.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	export let items: {
+		title: string;
+		description?: string;
+		time?: string;
+		icon?: string;
+		color?: string;
+	}[] = [];
+	export let variant: 'default' | 'compact' = 'default';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+</script>
+
+<div class="dss-timeline variant-{variant} size-{size}">
+	{#each items as item, i}
+		<div class="dss-timeline-item">
+			<div class="dss-timeline-indicator">
+				<span
+					class="dss-timeline-dot"
+					style={item.color ? `background: ${item.color}; border-color: ${item.color}` : ''}
+				>
+					{#if item.icon}
+						<span class="dss-timeline-icon">{item.icon}</span>
+					{/if}
+				</span>
+				{#if i < items.length - 1}
+					<div class="dss-timeline-line" />
+				{/if}
+			</div>
+			<div class="dss-timeline-content">
+				<div class="dss-timeline-header">
+					<span class="dss-timeline-title">{item.title}</span>
+					{#if item.time}
+						<span class="dss-timeline-time">{item.time}</span>
+					{/if}
+				</div>
+				{#if item.description}
+					<p class="dss-timeline-description">{item.description}</p>
+				{/if}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-timeline {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dss-timeline-item {
+		display: flex;
+		position: relative;
+	}
+
+	.dss-timeline-indicator {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
+	.dss-timeline-dot {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: var(--dss-radius-full, 9999px);
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		flex-shrink: 0;
+	}
+
+	.dss-timeline-icon {
+		font-size: 10px;
+		line-height: 1;
+		color: white;
+	}
+
+	.dss-timeline-line {
+		width: 2px;
+		flex: 1;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		min-height: 20px;
+	}
+
+	.dss-timeline-content {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.dss-timeline-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--dss-space-8, 8px);
+	}
+
+	.dss-timeline-title {
+		font-weight: 500;
+		color: var(--ssk-colors-text-900, #111827);
+	}
+
+	.dss-timeline-time {
+		color: var(--ssk-colors-text-400, #9ca3af);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.dss-timeline-description {
+		color: var(--ssk-colors-text-500, #6b7280);
+		margin: var(--dss-space-4, 4px) 0 0;
+		line-height: 1.5;
+	}
+
+	/* Sizes */
+	.size-sm .dss-timeline-dot { width: 10px; height: 10px; }
+	.size-sm .dss-timeline-content { padding: 0 0 var(--dss-space-16, 16px) var(--dss-space-12, 12px); }
+	.size-sm .dss-timeline-title { font-size: var(--dss-font-sm, 13px); }
+	.size-sm .dss-timeline-time { font-size: var(--dss-font-caption, 12px); }
+	.size-sm .dss-timeline-description { font-size: var(--dss-font-caption, 12px); }
+
+	.size-md .dss-timeline-dot { width: 12px; height: 12px; }
+	.size-md .dss-timeline-content { padding: 0 0 var(--dss-space-24, 24px) var(--dss-space-16, 16px); }
+	.size-md .dss-timeline-title { font-size: var(--dss-font-body, 14px); }
+	.size-md .dss-timeline-time { font-size: var(--dss-font-sm, 13px); }
+	.size-md .dss-timeline-description { font-size: var(--dss-font-sm, 13px); }
+
+	.size-lg .dss-timeline-dot { width: 16px; height: 16px; }
+	.size-lg .dss-timeline-content { padding: 0 0 32px var(--dss-space-24, 24px); }
+	.size-lg .dss-timeline-title { font-size: 15px; }
+	.size-lg .dss-timeline-time { font-size: var(--dss-font-body, 14px); }
+	.size-lg .dss-timeline-description { font-size: var(--dss-font-body, 14px); }
+
+	/* Compact variant */
+	.variant-compact .dss-timeline-content {
+		padding-bottom: var(--dss-space-12, 12px);
+	}
+	.variant-compact .dss-timeline-description {
+		display: none;
+	}
+
+	/* Last item no padding */
+	.dss-timeline-item:last-child .dss-timeline-content {
+		padding-bottom: 0;
+	}
+</style>

--- a/src/lib/svelte/navigation/Timeline.svelte
+++ b/src/lib/svelte/navigation/Timeline.svelte
@@ -63,9 +63,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		border-radius: var(--dss-radius-full, 9999px);
-		background: var(--ssk-colors-primary-500, #32a9ff);
-		border: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		border-radius: var(--radius-full, 9999px);
+		background: var(--primary, #32a9ff);
+		border: 2px solid var(--primary, #32a9ff);
 		flex-shrink: 0;
 	}
 
@@ -78,7 +78,7 @@
 	.dss-timeline-line {
 		width: 2px;
 		flex: 1;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 		min-height: 20px;
 	}
 
@@ -96,7 +96,7 @@
 
 	.dss-timeline-title {
 		font-weight: 500;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 	}
 
 	.dss-timeline-time {
@@ -106,7 +106,7 @@
 	}
 
 	.dss-timeline-description {
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		margin: var(--dss-space-4, 4px) 0 0;
 		line-height: 1.5;
 	}
@@ -114,21 +114,21 @@
 	/* Sizes */
 	.size-sm .dss-timeline-dot { width: 10px; height: 10px; }
 	.size-sm .dss-timeline-content { padding: 0 0 var(--dss-space-16, 16px) var(--dss-space-12, 12px); }
-	.size-sm .dss-timeline-title { font-size: var(--dss-font-sm, 13px); }
-	.size-sm .dss-timeline-time { font-size: var(--dss-font-caption, 12px); }
-	.size-sm .dss-timeline-description { font-size: var(--dss-font-caption, 12px); }
+	.size-sm .dss-timeline-title { font-size: var(--text-sm, 13px); }
+	.size-sm .dss-timeline-time { font-size: var(--text-caption, 12px); }
+	.size-sm .dss-timeline-description { font-size: var(--text-caption, 12px); }
 
 	.size-md .dss-timeline-dot { width: 12px; height: 12px; }
 	.size-md .dss-timeline-content { padding: 0 0 var(--dss-space-24, 24px) var(--dss-space-16, 16px); }
-	.size-md .dss-timeline-title { font-size: var(--dss-font-body, 14px); }
-	.size-md .dss-timeline-time { font-size: var(--dss-font-sm, 13px); }
-	.size-md .dss-timeline-description { font-size: var(--dss-font-sm, 13px); }
+	.size-md .dss-timeline-title { font-size: var(--text-p, 14px); }
+	.size-md .dss-timeline-time { font-size: var(--text-sm, 13px); }
+	.size-md .dss-timeline-description { font-size: var(--text-sm, 13px); }
 
 	.size-lg .dss-timeline-dot { width: 16px; height: 16px; }
 	.size-lg .dss-timeline-content { padding: 0 0 32px var(--dss-space-24, 24px); }
 	.size-lg .dss-timeline-title { font-size: 15px; }
-	.size-lg .dss-timeline-time { font-size: var(--dss-font-body, 14px); }
-	.size-lg .dss-timeline-description { font-size: var(--dss-font-body, 14px); }
+	.size-lg .dss-timeline-time { font-size: var(--text-p, 14px); }
+	.size-lg .dss-timeline-description { font-size: var(--text-p, 14px); }
 
 	/* Compact variant */
 	.variant-compact .dss-timeline-content {

--- a/src/lib/svelte/overlay/ConfirmDialog.svelte
+++ b/src/lib/svelte/overlay/ConfirmDialog.svelte
@@ -77,12 +77,12 @@
 		justify-content: center;
 		z-index: 100;
 		animation: dss-fade-in 0.15s;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.dss-confirm-dialog {
 		background: white;
-		border-radius: var(--dss-radius-lg, 12px);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
 		width: 100%;
 		max-width: 420px;
@@ -97,7 +97,7 @@
 		margin: 0;
 		font-size: 16px;
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		line-height: 1.4;
 	}
 
@@ -108,7 +108,7 @@
 	.confirm-description {
 		margin: 0;
 		font-size: 14px;
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.5;
 	}
 
@@ -121,7 +121,7 @@
 
 	.confirm-btn {
 		padding: var(--dss-space-8, 8px) var(--dss-space-16, 16px);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		font-size: 14px;
 		font-weight: 500;
 		cursor: pointer;
@@ -131,15 +131,15 @@
 	}
 
 	.btn-cancel {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-700, #374151);
 	}
 	.btn-cancel:hover {
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 
 	.btn-confirm.variant-default {
-		background: var(--ssk-colors-primary-500, #3b82f6);
+		background: var(--primary, #3b82f6);
 		color: white;
 	}
 	.btn-confirm.variant-default:hover {

--- a/src/lib/svelte/overlay/ConfirmDialog.svelte
+++ b/src/lib/svelte/overlay/ConfirmDialog.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let open: boolean = false;
+	export let title: string = 'Confirm';
+	export let description: string | undefined = undefined;
+	export let confirmLabel: string = 'Confirm';
+	export let cancelLabel: string = 'Cancel';
+	export let variant: 'default' | 'destructive' = 'default';
+
+	const dispatch = createEventDispatcher<{ confirm: void; close: void }>();
+
+	function handleConfirm() {
+		dispatch('confirm');
+		open = false;
+	}
+
+	function handleClose() {
+		dispatch('close');
+		open = false;
+	}
+
+	function handleBackdropClick() {
+		handleClose();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			handleClose();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+	<div class="dss-confirm-backdrop" on:click={handleBackdropClick} on:keypress role="presentation">
+		<div
+			class="dss-confirm-dialog"
+			on:click|stopPropagation
+			on:keypress
+			role="alertdialog"
+			aria-modal="true"
+			aria-labelledby="confirm-title"
+		>
+			<div class="confirm-header">
+				<h3 class="confirm-title" id="confirm-title">{title}</h3>
+			</div>
+			{#if description}
+				<div class="confirm-body">
+					<p class="confirm-description">{description}</p>
+				</div>
+			{/if}
+			<div class="confirm-footer">
+				<button class="confirm-btn btn-cancel" on:click={handleClose} type="button">
+					{cancelLabel}
+				</button>
+				<button
+					class="confirm-btn btn-confirm variant-{variant}"
+					on:click={handleConfirm}
+					type="button"
+				>
+					{confirmLabel}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dss-confirm-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+		animation: dss-fade-in 0.15s;
+		font-family: 'Inter', sans-serif;
+	}
+
+	.dss-confirm-dialog {
+		background: white;
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+		width: 100%;
+		max-width: 420px;
+		animation: dss-scale-in 0.15s;
+	}
+
+	.confirm-header {
+		padding: var(--dss-space-20, 20px) var(--dss-space-24, 24px) 0;
+	}
+
+	.confirm-title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+		line-height: 1.4;
+	}
+
+	.confirm-body {
+		padding: var(--dss-space-8, 8px) var(--dss-space-24, 24px) 0;
+	}
+
+	.confirm-description {
+		margin: 0;
+		font-size: 14px;
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.5;
+	}
+
+	.confirm-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--dss-space-8, 8px);
+		padding: var(--dss-space-20, 20px) var(--dss-space-24, 24px);
+	}
+
+	.confirm-btn {
+		padding: var(--dss-space-8, 8px) var(--dss-space-16, 16px);
+		border-radius: var(--dss-radius-md, 8px);
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		border: none;
+		transition: background 0.15s, opacity 0.15s;
+		line-height: 1.4;
+	}
+
+	.btn-cancel {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.btn-cancel:hover {
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.btn-confirm.variant-default {
+		background: var(--ssk-colors-primary-500, #3b82f6);
+		color: white;
+	}
+	.btn-confirm.variant-default:hover {
+		background: var(--ssk-colors-primary-600, #2563eb);
+	}
+
+	.btn-confirm.variant-destructive {
+		background: #ef4444;
+		color: white;
+	}
+	.btn-confirm.variant-destructive:hover {
+		background: #dc2626;
+	}
+
+	@keyframes dss-fade-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes dss-scale-in {
+		from { opacity: 0; transform: scale(0.95); }
+		to { opacity: 1; transform: scale(1); }
+	}
+</style>

--- a/src/lib/svelte/overlay/Drawer.svelte
+++ b/src/lib/svelte/overlay/Drawer.svelte
@@ -84,7 +84,7 @@
 		background: rgba(0, 0, 0, 0.4);
 		z-index: 100;
 		animation: dss-fade-in 0.15s;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.dss-drawer {
@@ -128,7 +128,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: var(--dss-space-16, 16px) var(--dss-space-20, 20px);
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 		flex-shrink: 0;
 	}
 
@@ -136,7 +136,7 @@
 		margin: 0;
 		font-size: 16px;
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		line-height: 1.4;
 	}
 
@@ -146,7 +146,7 @@
 		cursor: pointer;
 		padding: var(--dss-space-4, 4px);
 		color: var(--ssk-colors-text-400, #9ca3af);
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/src/lib/svelte/overlay/Drawer.svelte
+++ b/src/lib/svelte/overlay/Drawer.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let open: boolean = false;
+	export let title: string | undefined = undefined;
+	export let side: 'left' | 'right' | 'top' | 'bottom' = 'right';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+
+	const dispatch = createEventDispatcher<{ close: void }>();
+
+	const sizeMap: Record<string, string> = {
+		sm: '320px',
+		md: '480px',
+		lg: '640px'
+	};
+
+	function handleClose() {
+		open = false;
+		dispatch('close');
+	}
+
+	function handleBackdropClick() {
+		handleClose();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			handleClose();
+		}
+	}
+
+	$: panelStyle = (() => {
+		if (side === 'left' || side === 'right') {
+			return `width: ${sizeMap[size]}; max-width: 100vw;`;
+		}
+		return `height: ${sizeMap[size]}; max-height: 100vh;`;
+	})();
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+	<div class="dss-drawer-backdrop" on:click={handleBackdropClick} on:keypress role="presentation">
+		<div
+			class="dss-drawer side-{side}"
+			style={panelStyle}
+			on:click|stopPropagation
+			on:keypress
+			role="dialog"
+			aria-modal="true"
+		>
+			{#if title}
+				<div class="drawer-header">
+					<h3 class="drawer-title">{title}</h3>
+					<button class="drawer-close" on:click={handleClose} type="button" aria-label="Close">
+						<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+							<path d="M5 5l10 10M15 5l-10 10" />
+						</svg>
+					</button>
+				</div>
+			{:else}
+				<button class="drawer-close drawer-close-float" on:click={handleClose} type="button" aria-label="Close">
+					<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+						<path d="M5 5l10 10M15 5l-10 10" />
+					</svg>
+				</button>
+			{/if}
+
+			<div class="drawer-body">
+				<slot />
+			</div>
+
+			<slot name="footer">
+				<!-- optional footer slot -->
+			</slot>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dss-drawer-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		z-index: 100;
+		animation: dss-fade-in 0.15s;
+		font-family: 'Inter', sans-serif;
+	}
+
+	.dss-drawer {
+		position: fixed;
+		background: white;
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	/* Side positions */
+	.side-right {
+		top: 0;
+		right: 0;
+		bottom: 0;
+		animation: dss-slide-right 0.25s ease-out;
+	}
+	.side-left {
+		top: 0;
+		left: 0;
+		bottom: 0;
+		animation: dss-slide-left 0.25s ease-out;
+	}
+	.side-top {
+		top: 0;
+		left: 0;
+		right: 0;
+		animation: dss-slide-top 0.25s ease-out;
+	}
+	.side-bottom {
+		bottom: 0;
+		left: 0;
+		right: 0;
+		animation: dss-slide-bottom 0.25s ease-out;
+	}
+
+	/* Header */
+	.drawer-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--dss-space-16, 16px) var(--dss-space-20, 20px);
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		flex-shrink: 0;
+	}
+
+	.drawer-title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+		line-height: 1.4;
+	}
+
+	.drawer-close {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: var(--dss-space-4, 4px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+		border-radius: var(--dss-radius-sm, 4px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: color 0.15s;
+	}
+	.drawer-close:hover {
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.drawer-close-float {
+		position: absolute;
+		top: var(--dss-space-12, 12px);
+		right: var(--dss-space-12, 12px);
+		z-index: 1;
+	}
+
+	/* Body */
+	.drawer-body {
+		flex: 1;
+		overflow-y: auto;
+		padding: var(--dss-space-20, 20px);
+	}
+
+	/* Animations */
+	@keyframes dss-fade-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes dss-slide-right {
+		from { transform: translateX(100%); }
+		to { transform: translateX(0); }
+	}
+
+	@keyframes dss-slide-left {
+		from { transform: translateX(-100%); }
+		to { transform: translateX(0); }
+	}
+
+	@keyframes dss-slide-top {
+		from { transform: translateY(-100%); }
+		to { transform: translateY(0); }
+	}
+
+	@keyframes dss-slide-bottom {
+		from { transform: translateY(100%); }
+		to { transform: translateY(0); }
+	}
+</style>

--- a/src/lib/svelte/overlay/Dropdown.svelte
+++ b/src/lib/svelte/overlay/Dropdown.svelte
@@ -73,8 +73,8 @@
 		top: calc(100% + 4px);
 		left: 0;
 		background: white;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 		z-index: 50;
 		padding: 4px 0;

--- a/src/lib/svelte/overlay/Dropdown.svelte
+++ b/src/lib/svelte/overlay/Dropdown.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	export let themeColor: 'primary' | 'neutral' = 'primary';
+	export let optionsWidth: string = '200px';
+	export let width: 'auto' | 'full' = 'auto';
+
+	let open = false;
+	let dropdownEl: HTMLDivElement;
+
+	function toggle() {
+		open = !open;
+	}
+
+	function close() {
+		open = false;
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		if (dropdownEl && !dropdownEl.contains(e.target as Node)) {
+			close();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') close();
+	}
+</script>
+
+<svelte:window on:click={handleClickOutside} on:keydown={handleKeydown} />
+
+<div
+	class="dss-dropdown"
+	class:full-width={width === 'full'}
+	bind:this={dropdownEl}
+>
+	<div class="dropdown-trigger" on:click={toggle} on:keypress={toggle} role="button" tabindex="0">
+		<slot name="selected" />
+	</div>
+
+	{#if open}
+		<div
+			class="dropdown-menu theme-{themeColor}"
+			style:width={optionsWidth === 'auto' ? 'auto' : optionsWidth}
+			style:min-width={width === 'full' ? '100%' : undefined}
+			role="menu"
+			tabindex="-1"
+			on:click={close}
+			on:keypress
+		>
+			<slot />
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-dropdown {
+		position: relative;
+		display: inline-block;
+	}
+
+	.full-width {
+		display: block;
+		width: 100%;
+	}
+
+	.dropdown-trigger {
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+	}
+
+	.dropdown-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		background: white;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		z-index: 50;
+		padding: 4px 0;
+		overflow: hidden;
+	}
+
+</style>

--- a/src/lib/svelte/overlay/DropdownOption.svelte
+++ b/src/lib/svelte/overlay/DropdownOption.svelte
@@ -29,7 +29,7 @@
 		cursor: pointer;
 		transition: background 0.1s;
 		font-size: 14px;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 	}
 
 	.dss-dropdown-option:hover {

--- a/src/lib/svelte/overlay/DropdownOption.svelte
+++ b/src/lib/svelte/overlay/DropdownOption.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	function handleClick(e: MouseEvent) {
+		dispatch('click', e);
+	}
+</script>
+
+<div
+	class="dss-dropdown-option"
+	role="menuitem"
+	tabindex={$$restProps.tabindex ?? 0}
+	on:click={handleClick}
+	on:click
+	on:keypress
+>
+	<span class="option-prefix"><slot name="prefix" /></span>
+	<span class="option-content"><slot /></span>
+</div>
+
+<style>
+	.dss-dropdown-option {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 12px;
+		cursor: pointer;
+		transition: background 0.1s;
+		font-size: 14px;
+		color: var(--ssk-colors-text-900, #111827);
+	}
+
+	.dss-dropdown-option:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	.option-prefix {
+		display: inline-flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
+	.option-prefix:empty { display: none; }
+
+	.option-content {
+		flex: 1;
+		min-width: 0;
+	}
+</style>

--- a/src/lib/svelte/overlay/Menu.svelte
+++ b/src/lib/svelte/overlay/Menu.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+
+	export let items: MenuItem[] = [];
+	export let open: boolean = false;
+
+	const dispatch = createEventDispatcher();
+
+	interface MenuItem {
+		text?: string;
+		icon?: string;
+		shortcut?: string;
+		onClick?: () => void;
+		divider?: boolean;
+		label?: string;
+		destructive?: boolean;
+		disabled?: boolean;
+		children?: MenuItem[];
+	}
+
+	let menuEl: HTMLDivElement;
+	let activeSubmenu: number | null = null;
+
+	function handleSelect(item: MenuItem) {
+		if (item.disabled) return;
+		if (item.onClick) item.onClick();
+		dispatch('select', item);
+		open = false;
+		dispatch('close');
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		if (open && menuEl && !menuEl.contains(e.target as Node)) {
+			open = false;
+			dispatch('close');
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && open) {
+			open = false;
+			dispatch('close');
+		}
+	}
+
+	onMount(() => {
+		window.addEventListener('click', handleClickOutside, true);
+		window.addEventListener('keydown', handleKeydown);
+	});
+
+	onDestroy(() => {
+		window.removeEventListener('click', handleClickOutside, true);
+		window.removeEventListener('keydown', handleKeydown);
+	});
+</script>
+
+<div class="dss-menu-wrapper" bind:this={menuEl}>
+	<div class="dss-menu-trigger" on:click={() => { open = !open; }} on:keypress={() => { open = !open; }} role="button" tabindex={0}>
+		<slot name="trigger" />
+	</div>
+
+	{#if open}
+		<div class="dss-menu" role="menu">
+			{#each items as item, i}
+				{#if item.divider}
+					<div class="menu-divider" role="separator"></div>
+				{:else if item.label}
+					<div class="menu-label">{item.label}</div>
+				{:else}
+					<button
+						class="menu-item"
+						class:destructive={item.destructive}
+						class:disabled={item.disabled}
+						class:has-children={item.children && item.children.length > 0}
+						role="menuitem"
+						tabindex={item.disabled ? -1 : 0}
+						disabled={item.disabled}
+						on:click={() => handleSelect(item)}
+						on:mouseenter={() => { activeSubmenu = item.children ? i : null; }}
+						on:mouseleave={() => { if (activeSubmenu === i) activeSubmenu = null; }}
+					>
+						<span class="menu-item-text">{item.text || ''}</span>
+						{#if item.shortcut}
+							<span class="menu-item-shortcut">{item.shortcut}</span>
+						{/if}
+						{#if item.children && item.children.length > 0}
+							<svg class="submenu-arrow" width="12" height="12" viewBox="0 0 12 12" fill="none">
+								<path d="M4.5 3L7.5 6L4.5 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+
+							{#if activeSubmenu === i}
+								<div class="dss-menu dss-submenu" role="menu">
+									{#each item.children as child}
+										{#if child.divider}
+											<div class="menu-divider" role="separator"></div>
+										{:else}
+											<button
+												class="menu-item"
+												class:destructive={child.destructive}
+												class:disabled={child.disabled}
+												role="menuitem"
+												disabled={child.disabled}
+												on:click|stopPropagation={() => handleSelect(child)}
+											>
+												<span class="menu-item-text">{child.text || ''}</span>
+												{#if child.shortcut}
+													<span class="menu-item-shortcut">{child.shortcut}</span>
+												{/if}
+											</button>
+										{/if}
+									{/each}
+								</div>
+							{/if}
+						{/if}
+					</button>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-menu-wrapper {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.dss-menu-trigger {
+		cursor: pointer;
+	}
+
+	.dss-menu {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		z-index: 50;
+		min-width: 180px;
+		padding: var(--dss-space-4, 4px);
+		background: var(--dss-bg-primary, #ffffff);
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		animation: dss-menu-in 0.15s ease;
+	}
+
+	.dss-submenu {
+		position: absolute;
+		top: -4px;
+		left: 100%;
+		margin-left: 4px;
+	}
+
+	.menu-item {
+		display: flex;
+		align-items: center;
+		gap: var(--dss-space-8, 8px);
+		width: 100%;
+		padding: var(--dss-space-8, 8px) var(--dss-space-12, 12px);
+		border: none;
+		border-radius: var(--dss-radius-sm, 6px);
+		background: none;
+		cursor: pointer;
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-700, #374151);
+		text-align: left;
+		font-family: inherit;
+		position: relative;
+		transition: background 0.1s;
+	}
+
+	.menu-item:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	.menu-item.destructive {
+		color: #ef4444;
+	}
+	.menu-item.destructive:hover:not(:disabled) {
+		background: #fef2f2;
+	}
+
+	.menu-item:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.menu-item-text {
+		flex: 1;
+	}
+
+	.menu-item-shortcut {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.submenu-arrow {
+		flex-shrink: 0;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	.menu-divider {
+		height: 1px;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		margin: var(--dss-space-4, 4px) 0;
+	}
+
+	.menu-label {
+		padding: var(--dss-space-8, 8px) var(--dss-space-12, 12px) var(--dss-space-4, 4px);
+		font-size: var(--dss-font-caption, 12px);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+
+	@keyframes dss-menu-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+</style>

--- a/src/lib/svelte/overlay/Menu.svelte
+++ b/src/lib/svelte/overlay/Menu.svelte
@@ -137,8 +137,8 @@
 		min-width: 180px;
 		padding: var(--dss-space-4, 4px);
 		background: var(--dss-bg-primary, #ffffff);
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 		animation: dss-menu-in 0.15s ease;
 	}
@@ -157,10 +157,10 @@
 		width: 100%;
 		padding: var(--dss-space-8, 8px) var(--dss-space-12, 12px);
 		border: none;
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		background: none;
 		cursor: pointer;
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		color: var(--ssk-colors-text-700, #374151);
 		text-align: left;
 		font-family: inherit;
@@ -169,7 +169,7 @@
 	}
 
 	.menu-item:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 
 	.menu-item.destructive {
@@ -189,7 +189,7 @@
 	}
 
 	.menu-item-shortcut {
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: var(--ssk-colors-text-400, #9ca3af);
 	}
 
@@ -200,13 +200,13 @@
 
 	.menu-divider {
 		height: 1px;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 		margin: var(--dss-space-4, 4px) 0;
 	}
 
 	.menu-label {
 		padding: var(--dss-space-8, 8px) var(--dss-space-12, 12px) var(--dss-space-4, 4px);
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;

--- a/src/lib/svelte/overlay/Modal.svelte
+++ b/src/lib/svelte/overlay/Modal.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	export let open: boolean = false;
+
+	function handleBackdropClick() {
+		open = false;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			open = false;
+		}
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+	<div class="dss-modal-backdrop" on:click={handleBackdropClick} on:keypress role="presentation">
+		<div class="dss-modal" on:click|stopPropagation on:keypress role="dialog" aria-modal="true">
+			<slot />
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dss-modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+		animation: dss-fade-in 0.15s;
+	}
+
+	.dss-modal {
+		background: white;
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+		max-width: 90vw;
+		max-height: 90vh;
+		overflow-y: auto;
+		animation: dss-scale-in 0.15s;
+	}
+
+	@keyframes dss-fade-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes dss-scale-in {
+		from { opacity: 0; transform: scale(0.95); }
+		to { opacity: 1; transform: scale(1); }
+	}
+</style>

--- a/src/lib/svelte/overlay/Modal.svelte
+++ b/src/lib/svelte/overlay/Modal.svelte
@@ -36,7 +36,7 @@
 
 	.dss-modal {
 		background: white;
-		border-radius: var(--dss-radius-lg, 12px);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
 		max-width: 90vw;
 		max-height: 90vh;

--- a/src/lib/svelte/overlay/Popover.svelte
+++ b/src/lib/svelte/overlay/Popover.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let placement: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+	export let title: string | undefined = undefined;
+	export let open: boolean = false;
+
+	const dispatch = createEventDispatcher<{ openChange: { open: boolean } }>();
+
+	function toggle() {
+		open = !open;
+		dispatch('openChange', { open });
+	}
+
+	function close() {
+		if (!open) return;
+		open = false;
+		dispatch('openChange', { open });
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			close();
+		}
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.dss-popover-wrapper')) {
+			close();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} on:click={handleClickOutside} />
+
+<div class="dss-popover-wrapper">
+	<div class="dss-popover-trigger" on:click|stopPropagation={toggle} on:keypress role="button" tabindex="0">
+		<slot name="trigger" />
+	</div>
+	{#if open}
+		<div class="dss-popover placement-{placement}" on:click|stopPropagation on:keypress role="dialog">
+			{#if title}
+				<div class="popover-header">{title}</div>
+			{/if}
+			<div class="popover-content">
+				<slot />
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-popover-wrapper {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.dss-popover-trigger {
+		display: inline-flex;
+		cursor: pointer;
+	}
+
+	.dss-popover {
+		position: absolute;
+		z-index: 200;
+		background: white;
+		border-radius: var(--dss-radius-lg, 12px);
+		box-shadow: var(--dss-shadow-sm, 0 4px 12px rgba(0, 0, 0, 0.12));
+		min-width: 200px;
+		animation: dss-popover-in 0.15s ease-out;
+		font-family: 'Inter', sans-serif;
+	}
+
+	.placement-bottom {
+		top: calc(100% + 8px);
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	.placement-top {
+		bottom: calc(100% + 8px);
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	.placement-left {
+		right: calc(100% + 8px);
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	.placement-right {
+		left: calc(100% + 8px);
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	.popover-header {
+		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--ssk-colors-text-900, #111827);
+		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	.popover-content {
+		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
+	}
+
+	@keyframes dss-popover-in {
+		from { opacity: 0; transform: translateX(-50%) translateY(4px); }
+		to { opacity: 1; transform: translateX(-50%) translateY(0); }
+	}
+
+	.placement-top + .dss-popover,
+	:global(.placement-top) {
+		/* override animation for top */
+	}
+
+	@keyframes dss-popover-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+</style>

--- a/src/lib/svelte/overlay/Popover.svelte
+++ b/src/lib/svelte/overlay/Popover.svelte
@@ -65,11 +65,11 @@
 		position: absolute;
 		z-index: 200;
 		background: white;
-		border-radius: var(--dss-radius-lg, 12px);
+		border-radius: var(--radius-lg, 12px);
 		box-shadow: var(--dss-shadow-sm, 0 4px 12px rgba(0, 0, 0, 0.12));
 		min-width: 200px;
 		animation: dss-popover-in 0.15s ease-out;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.placement-bottom {
@@ -100,8 +100,8 @@
 		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
 		font-size: 14px;
 		font-weight: 600;
-		color: var(--ssk-colors-text-900, #111827);
-		border-bottom: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--foreground, #111827);
+		border-bottom: 1px solid var(--muted, #f3f4f6);
 	}
 
 	.popover-content {

--- a/src/lib/svelte/overlay/ToastContainer.svelte
+++ b/src/lib/svelte/overlay/ToastContainer.svelte
@@ -39,7 +39,7 @@
 		align-items: center;
 		gap: 10px;
 		padding: 12px 16px;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 		font-size: 14px;
 		animation: dss-toast-in 0.2s ease-out;

--- a/src/lib/svelte/overlay/ToastContainer.svelte
+++ b/src/lib/svelte/overlay/ToastContainer.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { toasts } from '$lib/stores/toast';
+	import Icon from '../ui/Icon.svelte';
+
+	const variantIcons: Record<string, string> = {
+		info: 'Info',
+		success: 'CheckCircle2',
+		warning: 'AlertTriangle',
+		error: 'XCircle'
+	};
+</script>
+
+<div class="dss-toast-container">
+	{#each $toasts as toast (toast.id)}
+		<div class="toast variant-{toast.variant}">
+			<Icon name={variantIcons[toast.variant]} size="sm" />
+			<span class="toast-message">{toast.message}</span>
+			<button class="toast-close" on:click={() => toasts.remove(toast.id)} type="button">
+				<Icon name="X" size="xs" />
+			</button>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-toast-container {
+		position: fixed;
+		top: 16px;
+		right: 16px;
+		z-index: 9999;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		max-width: 400px;
+	}
+
+	.toast {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 12px 16px;
+		border-radius: var(--dss-radius-md, 8px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		font-size: 14px;
+		animation: dss-toast-in 0.2s ease-out;
+	}
+
+	.variant-info { background: #eff6ff; color: #1e40af; }
+	.variant-success { background: #f0fdf4; color: #166534; }
+	.variant-warning { background: #fffbeb; color: #92400e; }
+	.variant-error { background: #fef2f2; color: #991b1b; }
+
+	.toast-message { flex: 1; }
+
+	.toast-close {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 2px;
+		color: inherit;
+		opacity: 0.6;
+	}
+
+	.toast-close:hover { opacity: 1; }
+
+	@keyframes dss-toast-in {
+		from { opacity: 0; transform: translateX(20px); }
+		to { opacity: 1; transform: translateX(0); }
+	}
+</style>

--- a/src/lib/svelte/overlay/Tooltip.svelte
+++ b/src/lib/svelte/overlay/Tooltip.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	export let content: string;
+	export let placement: 'top' | 'right' | 'bottom' | 'left' = 'top';
+
+	let visible = false;
+
+	function show() { visible = true; }
+	function hide() { visible = false; }
+</script>
+
+<div
+	class="dss-tooltip-wrapper"
+	on:mouseenter={show}
+	on:mouseleave={hide}
+	on:focusin={show}
+	on:focusout={hide}
+>
+	<slot />
+	{#if visible}
+		<div class="dss-tooltip placement-{placement}" role="tooltip">
+			{content}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-tooltip-wrapper {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.dss-tooltip {
+		position: absolute;
+		z-index: 1000;
+		background: var(--ssk-colors-neutral-800, #1f2937);
+		color: white;
+		font-size: 12px;
+		line-height: 1.4;
+		padding: var(--dss-space-4, 4px) var(--dss-space-8, 8px);
+		border-radius: var(--dss-radius-sm, 4px);
+		white-space: nowrap;
+		pointer-events: none;
+		animation: dss-tooltip-fade 0.15s ease-out;
+		font-family: 'Inter', sans-serif;
+	}
+
+	/* Arrow via ::after */
+	.dss-tooltip::after {
+		content: '';
+		position: absolute;
+		border: 5px solid transparent;
+	}
+
+	/* Placement: top */
+	.placement-top {
+		bottom: calc(100% + 8px);
+		left: 50%;
+		transform: translateX(-50%);
+	}
+	.placement-top::after {
+		top: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		border-top-color: var(--ssk-colors-neutral-800, #1f2937);
+	}
+
+	/* Placement: bottom */
+	.placement-bottom {
+		top: calc(100% + 8px);
+		left: 50%;
+		transform: translateX(-50%);
+	}
+	.placement-bottom::after {
+		bottom: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		border-bottom-color: var(--ssk-colors-neutral-800, #1f2937);
+	}
+
+	/* Placement: left */
+	.placement-left {
+		right: calc(100% + 8px);
+		top: 50%;
+		transform: translateY(-50%);
+	}
+	.placement-left::after {
+		left: 100%;
+		top: 50%;
+		transform: translateY(-50%);
+		border-left-color: var(--ssk-colors-neutral-800, #1f2937);
+	}
+
+	/* Placement: right */
+	.placement-right {
+		left: calc(100% + 8px);
+		top: 50%;
+		transform: translateY(-50%);
+	}
+	.placement-right::after {
+		right: 100%;
+		top: 50%;
+		transform: translateY(-50%);
+		border-right-color: var(--ssk-colors-neutral-800, #1f2937);
+	}
+
+	@keyframes dss-tooltip-fade {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+</style>

--- a/src/lib/svelte/overlay/Tooltip.svelte
+++ b/src/lib/svelte/overlay/Tooltip.svelte
@@ -37,11 +37,11 @@
 		font-size: 12px;
 		line-height: 1.4;
 		padding: var(--dss-space-4, 4px) var(--dss-space-8, 8px);
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		white-space: nowrap;
 		pointer-events: none;
 		animation: dss-tooltip-fade 0.15s ease-out;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	/* Arrow via ::after */

--- a/src/lib/svelte/styles/tokens.css
+++ b/src/lib/svelte/styles/tokens.css
@@ -65,4 +65,46 @@
 	--dss-radius-lg: var(--Border-radius--radius-lg, 12px);
 	--dss-radius-xl: var(--Border-radius--radius-xl, 16px);
 	--dss-radius-full: var(--Border-radius--radius-full, 9999px);
+
+	/* ─── Typography (DB HeaventRounded — DS Spec) ─────────────────────── */
+	--font-label: 'DB HeaventRounded', 'Noto Sans Thai', system-ui, sans-serif;
+	--dss-font-family: 'DB HeaventRounded', 'Noto Sans Thai', system-ui, sans-serif;
+	--dss-font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+
+	--dss-font-h1: 36px;
+	--dss-font-h2: 32px;
+	--dss-font-h3: 28px;
+	--dss-font-h4: 24px;
+	--dss-font-body: 20px;
+	--dss-font-sm: 16px;
+	--dss-font-caption: 14px;
+	--dss-font-label: 18px;
+	--dss-font-button: 18px;
+
+	/* Text scale tokens (React DS compatible) */
+	--text-h1: var(--dss-font-h1);
+	--text-h2: var(--dss-font-h2);
+	--text-h3: var(--dss-font-h3);
+	--text-h4: var(--dss-font-h4);
+	--text-p: var(--dss-font-body);
+	--text-sm: var(--dss-font-sm);
+	--text-caption: var(--dss-font-caption);
+	--text-label: var(--dss-font-label);
+	--text-button: var(--dss-font-button);
+
+	/* ─── Semantic color aliases (React DS compatible) ───────────────────── */
+	--primary: var(--ssk-colors-primary-500);
+	--primary-foreground: #ffffff;
+	--muted: var(--ssk-colors-neutral-100);
+	--muted-foreground: var(--ssk-colors-text-500);
+	--foreground: var(--ssk-colors-text-900);
+	--border: var(--ssk-colors-neutral-200);
+
+	/* ─── Radius aliases (React DS compatible) ───────────────────────────── */
+	--radius-xs: var(--dss-radius-xs);
+	--radius-sm: var(--dss-radius-sm);
+	--radius-md: var(--dss-radius-md);
+	--radius-lg: var(--dss-radius-lg);
+	--radius-xl: var(--dss-radius-xl);
+	--radius-full: var(--dss-radius-full);
 }

--- a/src/lib/svelte/styles/tokens.css
+++ b/src/lib/svelte/styles/tokens.css
@@ -1,0 +1,68 @@
+/* Design System Tokens Bridge
+ * Maps DSS (@uxuissk/design-system) variables to backward-compatible --ssk-colors-* aliases
+ * and provides semantic design tokens for the app.
+ */
+
+/* DSS tokens are imported via main.ts: import '@uxuissk/design-system/styles.css' */
+
+:root {
+	/* ─── Backward-compatible aliases (ssk → DSS) ────────────────────────── */
+
+	/* Primary (Sky Blue — DSS brand) */
+	--ssk-colors-primary-50: var(--Base_Color--Sky--50, #f0f9ff);
+	--ssk-colors-primary-100: var(--Base_Color--Sky--100, #d9f2ff);
+	--ssk-colors-primary-200: var(--Base_Color--Sky--200, #bce8ff);
+	--ssk-colors-primary-300: var(--Base_Color--Sky--300, #8edcff);
+	--ssk-colors-primary-400: var(--Base_Color--Sky--400, #58c6ff);
+	--ssk-colors-primary-500: var(--Base_Color--Sky--500, #32a9ff);
+	--ssk-colors-primary-600: var(--Base_Color--Sky--600, #1b8bf5);
+	--ssk-colors-primary-700: var(--Base_Color--Sky--700, #1473e1);
+	--ssk-colors-primary-800: var(--Base_Color--Sky--800, #175cb6);
+	--ssk-colors-primary-900: var(--Base_Color--Sky--900, #194f8f);
+
+	/* Secondary (Orange) */
+	--ssk-colors-secondary-50: var(--Base_Color--Orange--50, #fff7ed);
+	--ssk-colors-secondary-100: var(--Base_Color--Orange--100, #ffedd5);
+	--ssk-colors-secondary-200: var(--Base_Color--Orange--200, #fed7aa);
+	--ssk-colors-secondary-300: var(--Base_Color--Orange--300, #fdba74);
+	--ssk-colors-secondary-400: var(--Base_Color--Orange--400, #fb923c);
+	--ssk-colors-secondary-500: var(--Base_Color--Orange--500, #f97316);
+	--ssk-colors-secondary-600: var(--Base_Color--Orange--600, #ea580c);
+	--ssk-colors-secondary-700: var(--Base_Color--Orange--700, #c2410c);
+	--ssk-colors-secondary-800: var(--Base_Color--Orange--800, #9a3412);
+	--ssk-colors-secondary-900: var(--Base_Color--Orange--900, #7c2d12);
+
+	/* Neutral (Gray) */
+	--ssk-colors-neutral-50: var(--Base_Color--Gray--50, #f9fafb);
+	--ssk-colors-neutral-100: var(--Base_Color--Gray--100, #f3f4f6);
+	--ssk-colors-neutral-200: var(--Base_Color--Gray--200, #e5e7eb);
+	--ssk-colors-neutral-300: var(--Base_Color--Gray--300, #d1d5db);
+	--ssk-colors-neutral-400: var(--Base_Color--Gray--400, #9ca3af);
+	--ssk-colors-neutral-500: var(--Base_Color--Gray--500, #6b7280);
+	--ssk-colors-neutral-600: var(--Base_Color--Gray--600, #4b5563);
+	--ssk-colors-neutral-700: var(--Base_Color--Gray--700, #374151);
+	--ssk-colors-neutral-800: var(--Base_Color--Gray--800, #1f2937);
+	--ssk-colors-neutral-900: var(--Base_Color--Gray--900, #111827);
+
+	/* Text */
+	--ssk-colors-text-900: var(--Colors--Text--text-primary, #111827);
+	--ssk-colors-text-700: var(--Colors--Text--text-secondary, #374151);
+	--ssk-colors-text-500: var(--Colors--Text--text-tertiary, #6b7280);
+	--ssk-colors-text-400: var(--Colors--Text--text-placeholder, #9ca3af);
+
+	/* ─── Semantic tokens ────────────────────────────────────────────────── */
+	--dss-bg-primary: var(--Colors--Background--bg-primary, #ffffff);
+	--dss-bg-secondary: var(--Colors--Background--bg-secondary, #f9fafb);
+	--dss-bg-tertiary: var(--Colors--Background--bg-tertiary, #f3f4f6);
+	--dss-bg-active: var(--Colors--Background--bg-active, #f3f4f6);
+	--dss-bg-brand-solid: var(--Colors--Background--bg-brand-solid, #FF8D00);
+	--dss-bg-disabled: var(--Colors--Background--bg-disabled, #f3f4f6);
+
+	/* Border radius */
+	--dss-radius-xs: var(--Border-radius--radius-xs, 4px);
+	--dss-radius-sm: var(--Border-radius--radius-sm, 6px);
+	--dss-radius-md: var(--Border-radius--radius-md, 8px);
+	--dss-radius-lg: var(--Border-radius--radius-lg, 12px);
+	--dss-radius-xl: var(--Border-radius--radius-xl, 16px);
+	--dss-radius-full: var(--Border-radius--radius-full, 9999px);
+}

--- a/src/lib/svelte/ui/Accordion.svelte
+++ b/src/lib/svelte/ui/Accordion.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let type: 'single' | 'multiple' = 'single';
+	export let items: { id: string; title: string; content: string; icon?: string }[] = [];
+	export let defaultOpen: string | string[] | undefined = undefined;
+	export let value: string | string[] | null = null;
+
+	const dispatch = createEventDispatcher();
+
+	let openItems: Set<string> = new Set();
+
+	// Initialize from defaultOpen
+	if (defaultOpen) {
+		if (Array.isArray(defaultOpen)) {
+			openItems = new Set(defaultOpen);
+		} else {
+			openItems = new Set([defaultOpen]);
+		}
+	}
+
+	// Sync from value prop
+	$: if (value !== null) {
+		if (Array.isArray(value)) {
+			openItems = new Set(value);
+		} else {
+			openItems = new Set([value]);
+		}
+	}
+
+	function toggle(id: string) {
+		if (type === 'single') {
+			if (openItems.has(id)) {
+				openItems = new Set();
+			} else {
+				openItems = new Set([id]);
+			}
+		} else {
+			const next = new Set(openItems);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			openItems = next;
+		}
+
+		const emitValue = type === 'single'
+			? (openItems.size > 0 ? [...openItems][0] : null)
+			: [...openItems];
+		dispatch('change', emitValue);
+	}
+</script>
+
+<div class="dss-accordion">
+	{#each items as item (item.id)}
+		<div class="dss-accordion-item" class:open={openItems.has(item.id)}>
+			<button
+				class="dss-accordion-trigger"
+				on:click={() => toggle(item.id)}
+				aria-expanded={openItems.has(item.id)}
+			>
+				{#if item.icon}
+					<span class="dss-accordion-icon">{item.icon}</span>
+				{/if}
+				<span class="dss-accordion-title">{item.title}</span>
+				<svg
+					class="dss-accordion-chevron"
+					class:rotated={openItems.has(item.id)}
+					width="16" height="16" viewBox="0 0 16 16" fill="none"
+				>
+					<path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</button>
+			{#if openItems.has(item.id)}
+				<div class="dss-accordion-content">
+					{item.content}
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style>
+	.dss-accordion {
+		width: 100%;
+		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+	}
+
+	.dss-accordion-item {
+		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.dss-accordion-item:last-child {
+		border-bottom: none;
+	}
+
+	.dss-accordion-trigger {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		padding: var(--dss-space-12, 12px) var(--dss-space-16, 16px);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		font-size: var(--dss-font-body, 14px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-900, #111827);
+		text-align: left;
+		gap: var(--dss-space-8, 8px);
+		transition: background 0.15s;
+	}
+	.dss-accordion-trigger:hover {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	.dss-accordion-icon {
+		flex-shrink: 0;
+	}
+
+	.dss-accordion-title {
+		flex: 1;
+	}
+
+	.dss-accordion-chevron {
+		flex-shrink: 0;
+		color: var(--ssk-colors-text-400, #9ca3af);
+		transition: transform 0.2s ease;
+	}
+	.dss-accordion-chevron.rotated {
+		transform: rotate(180deg);
+	}
+
+	.dss-accordion-content {
+		padding: 0 var(--dss-space-16, 16px) var(--dss-space-16, 16px);
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-500, #6b7280);
+		line-height: 1.5;
+	}
+</style>

--- a/src/lib/svelte/ui/Accordion.svelte
+++ b/src/lib/svelte/ui/Accordion.svelte
@@ -84,13 +84,13 @@
 <style>
 	.dss-accordion {
 		width: 100%;
-		border: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
-		border-radius: var(--dss-radius-md, 8px);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
 	}
 
 	.dss-accordion-item {
-		border-bottom: 1px solid var(--ssk-colors-neutral-200, #e5e7eb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
 	}
 	.dss-accordion-item:last-child {
 		border-bottom: none;
@@ -104,9 +104,9 @@
 		background: transparent;
 		border: none;
 		cursor: pointer;
-		font-size: var(--dss-font-body, 14px);
+		font-size: var(--text-p, 14px);
 		font-weight: 500;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		text-align: left;
 		gap: var(--dss-space-8, 8px);
 		transition: background 0.15s;
@@ -134,8 +134,8 @@
 
 	.dss-accordion-content {
 		padding: 0 var(--dss-space-16, 16px) var(--dss-space-16, 16px);
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-p, 14px);
+		color: var(--muted-foreground, #6b7280);
 		line-height: 1.5;
 	}
 </style>

--- a/src/lib/svelte/ui/Avatar.svelte
+++ b/src/lib/svelte/ui/Avatar.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	export let src: string = '';
+	export let alt: string = '';
+	export let name: string = '';
+	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
+	export let shape: 'circle' | 'square' = 'circle';
+	export let boxsize: string = '';
+
+	const sizeMap: Record<string, string> = {
+		xs: '24px',
+		sm: '32px',
+		md: '40px',
+		lg: '48px',
+		xl: '64px'
+	};
+
+	$: computedSize = boxsize || sizeMap[size] || '40px';
+	$: initials = name
+		? name
+				.split(' ')
+				.map((n) => n[0])
+				.join('')
+				.toUpperCase()
+				.slice(0, 2)
+		: '';
+</script>
+
+<div
+	class="dss-avatar shape-{shape}"
+	style:width={computedSize}
+	style:height={computedSize}
+	on:click
+	on:keypress
+	role={$$restProps.role || undefined}
+	tabindex={$$restProps.tabindex || undefined}
+>
+	{#if src}
+		<img {src} alt={alt || name} class="avatar-img" />
+	{:else if initials}
+		<span class="avatar-initials">{initials}</span>
+	{:else}
+		<span class="avatar-fallback">?</span>
+	{/if}
+</div>
+
+<style>
+	.dss-avatar {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		flex-shrink: 0;
+	}
+
+	.shape-circle { border-radius: 50%; }
+	.shape-square { border-radius: var(--dss-radius-md, 8px); }
+
+	.avatar-img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.avatar-initials,
+	.avatar-fallback {
+		font-size: 0.45em;
+		font-weight: 600;
+		color: var(--ssk-colors-neutral-600, #4b5563);
+		user-select: none;
+	}
+</style>

--- a/src/lib/svelte/ui/Avatar.svelte
+++ b/src/lib/svelte/ui/Avatar.svelte
@@ -49,12 +49,12 @@
 		align-items: center;
 		justify-content: center;
 		overflow: hidden;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 		flex-shrink: 0;
 	}
 
 	.shape-circle { border-radius: 50%; }
-	.shape-square { border-radius: var(--dss-radius-md, 8px); }
+	.shape-square { border-radius: var(--radius-md, 8px); }
 
 	.avatar-img {
 		width: 100%;

--- a/src/lib/svelte/ui/AvatarGroup.svelte
+++ b/src/lib/svelte/ui/AvatarGroup.svelte
@@ -57,7 +57,7 @@
 		width: 40px;
 		height: 40px;
 		border-radius: 50%;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 		margin-left: -8px;
 		border: 2px solid white;
 		box-sizing: content-box;
@@ -65,7 +65,7 @@
 	}
 
 	.overflow-text {
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 600;
 		color: var(--ssk-colors-text-700, #374151);
 		user-select: none;

--- a/src/lib/svelte/ui/AvatarGroup.svelte
+++ b/src/lib/svelte/ui/AvatarGroup.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	export let max: number = 4;
+
+	let wrapperEl: HTMLDivElement;
+
+	$: totalChildren = wrapperEl?.children?.length ?? 0;
+	$: overflow = Math.max(0, totalChildren - max);
+
+	function updateVisibility() {
+		if (!wrapperEl) return;
+		const children = Array.from(wrapperEl.children) as HTMLElement[];
+		totalChildren = children.length;
+		children.forEach((child, i) => {
+			if (child.classList.contains('dss-avatar-group-overflow')) return;
+			child.style.display = i < max ? '' : 'none';
+			child.style.zIndex = String(children.length - i);
+		});
+	}
+
+	// Re-run on DOM changes
+	$: if (wrapperEl && max) {
+		requestAnimationFrame(updateVisibility);
+	}
+</script>
+
+<div class="dss-avatar-group" bind:this={wrapperEl} on:introstart={updateVisibility}>
+	<slot />
+	{#if overflow > 0}
+		<div class="dss-avatar-group-overflow" style:z-index="0">
+			<span class="overflow-text">+{overflow}</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-avatar-group {
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+	}
+
+	.dss-avatar-group > :global(*) {
+		margin-left: -8px;
+		border: 2px solid white;
+		border-radius: 50%;
+		box-sizing: content-box;
+	}
+
+	.dss-avatar-group > :global(*:first-child) {
+		margin-left: 0;
+	}
+
+	.dss-avatar-group-overflow {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		margin-left: -8px;
+		border: 2px solid white;
+		box-sizing: content-box;
+		flex-shrink: 0;
+	}
+
+	.overflow-text {
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 600;
+		color: var(--ssk-colors-text-700, #374151);
+		user-select: none;
+	}
+</style>

--- a/src/lib/svelte/ui/Badge.svelte
+++ b/src/lib/svelte/ui/Badge.svelte
@@ -11,7 +11,7 @@
 	.dss-badge {
 		display: inline-flex;
 		align-items: center;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		font-weight: 500;
 		white-space: nowrap;
 	}
@@ -23,11 +23,11 @@
 
 	/* Variants */
 	.variant-default {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
 	}
 	.variant-secondary {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-neutral-700, #374151);
 	}
 	.variant-outline {

--- a/src/lib/svelte/ui/Badge.svelte
+++ b/src/lib/svelte/ui/Badge.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	export let variant: 'default' | 'secondary' | 'outline' | 'destructive' | 'success' | 'warning' = 'default';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+</script>
+
+<span class="dss-badge variant-{variant} size-{size}">
+	<slot />
+</span>
+
+<style>
+	.dss-badge {
+		display: inline-flex;
+		align-items: center;
+		border-radius: var(--dss-radius-full, 9999px);
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	/* Sizes */
+	.size-sm { padding: 1px 6px; font-size: 11px; }
+	.size-md { padding: 2px 8px; font-size: 12px; }
+	.size-lg { padding: 3px 10px; font-size: 13px; }
+
+	/* Variants */
+	.variant-default {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+	}
+	.variant-secondary {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-neutral-700, #374151);
+	}
+	.variant-outline {
+		background: transparent;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		color: var(--ssk-colors-neutral-700, #374151);
+	}
+	.variant-destructive {
+		background: var(--ssk-colors-secondary-500, #FF0006);
+		color: white;
+	}
+	.variant-success {
+		background: #10b981;
+		color: white;
+	}
+	.variant-warning {
+		background: #f59e0b;
+		color: white;
+	}
+</style>

--- a/src/lib/svelte/ui/Button.svelte
+++ b/src/lib/svelte/ui/Button.svelte
@@ -32,12 +32,12 @@
 		justify-content: center;
 		gap: 6px;
 		border: none;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		font-weight: 600;
 		cursor: pointer;
 		transition: background 0.15s, color 0.15s, border-color 0.15s;
 		white-space: nowrap;
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.dss-btn:disabled {
@@ -55,9 +55,9 @@
 
 	/* Primary — Sky-500 */
 	.variant-primary {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
-		border: 1px solid var(--ssk-colors-primary-500, #32a9ff);
+		border: 1px solid var(--primary, #32a9ff);
 	}
 	.variant-primary:hover:not(:disabled) {
 		background: var(--ssk-colors-primary-600, #1b8bf5);
@@ -66,12 +66,12 @@
 
 	/* Secondary */
 	.variant-secondary {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-neutral-700, #374151);
-		border: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+		border: 1px solid var(--muted, #f3f4f6);
 	}
 	.variant-secondary:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 
 	/* Outline */
@@ -91,7 +91,7 @@
 		border: 1px solid transparent;
 	}
 	.variant-ghost:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 
 	/* Destructive */
@@ -107,7 +107,7 @@
 	/* Link */
 	.variant-link {
 		background: transparent;
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 		border: none;
 		padding: 0;
 		height: auto;

--- a/src/lib/svelte/ui/Button.svelte
+++ b/src/lib/svelte/ui/Button.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	export let variant: 'primary' | 'secondary' | 'outline' | 'ghost' | 'destructive' | 'link' = 'primary';
+	export let size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+	export let loading: boolean = false;
+	export let disabled: boolean = false;
+	export let fullWidth: boolean = false;
+	export let title: string = '';
+	export let type: 'button' | 'submit' | 'reset' = 'button';
+</script>
+
+<button
+	class="dss-btn variant-{variant} size-{size}"
+	class:full-width={fullWidth}
+	{disabled}
+	{title}
+	{type}
+	on:click
+	on:keypress
+>
+	{#if loading}
+		<span class="spinner" />
+	{/if}
+	<slot name="prefix" />
+	<slot />
+	<slot name="suffix" />
+</button>
+
+<style>
+	.dss-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		border: none;
+		border-radius: var(--dss-radius-md, 8px);
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
+		white-space: nowrap;
+		font-family: 'Inter', sans-serif;
+	}
+
+	.dss-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.full-width { width: 100%; }
+
+	/* Sizes */
+	.size-sm { padding: 6px 12px; font-size: 13px; height: 32px; }
+	.size-md { padding: 8px 16px; font-size: 14px; height: 36px; }
+	.size-lg { padding: 10px 20px; font-size: 15px; height: 40px; }
+	.size-xl { padding: 12px 24px; font-size: 16px; height: 44px; }
+
+	/* Primary — Sky-500 */
+	.variant-primary {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		border: 1px solid var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.variant-primary:hover:not(:disabled) {
+		background: var(--ssk-colors-primary-600, #1b8bf5);
+		border-color: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	/* Secondary */
+	.variant-secondary {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-neutral-700, #374151);
+		border: 1px solid var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+	.variant-secondary:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	/* Outline */
+	.variant-outline {
+		background: transparent;
+		color: var(--ssk-colors-neutral-700, #374151);
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outline:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	/* Ghost */
+	.variant-ghost {
+		background: transparent;
+		color: var(--ssk-colors-neutral-700, #374151);
+		border: 1px solid transparent;
+	}
+	.variant-ghost:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	/* Destructive */
+	.variant-destructive {
+		background: var(--ssk-colors-secondary-500, #FF0006);
+		color: white;
+		border: 1px solid var(--ssk-colors-secondary-500, #FF0006);
+	}
+	.variant-destructive:hover:not(:disabled) {
+		background: var(--ssk-colors-secondary-600, #D90005);
+	}
+
+	/* Link */
+	.variant-link {
+		background: transparent;
+		color: var(--ssk-colors-primary-500, #32a9ff);
+		border: none;
+		padding: 0;
+		height: auto;
+		text-decoration: underline;
+	}
+	.variant-link:hover:not(:disabled) {
+		color: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	/* Loading spinner */
+	.spinner {
+		width: 14px;
+		height: 14px;
+		border: 2px solid currentColor;
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: dss-btn-spin 0.6s linear infinite;
+	}
+
+	@keyframes dss-btn-spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/src/lib/svelte/ui/ButtonGroup.svelte
+++ b/src/lib/svelte/ui/ButtonGroup.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	// Wrapper that connects child buttons visually
+</script>
+
+<div class="dss-button-group" role="group">
+	<slot />
+</div>
+
+<style>
+	.dss-button-group {
+		display: inline-flex;
+	}
+
+	.dss-button-group > :global(.dss-btn) {
+		border-radius: 0;
+		margin-left: -1px;
+	}
+
+	.dss-button-group > :global(.dss-btn:first-child) {
+		border-radius: var(--dss-radius-sm, 6px) 0 0 var(--dss-radius-sm, 6px);
+		margin-left: 0;
+	}
+
+	.dss-button-group > :global(.dss-btn:last-child) {
+		border-radius: 0 var(--dss-radius-sm, 6px) var(--dss-radius-sm, 6px) 0;
+	}
+
+	.dss-button-group > :global(.dss-btn:only-child) {
+		border-radius: var(--dss-radius-sm, 6px);
+	}
+
+	.dss-button-group > :global(.dss-btn:hover),
+	.dss-button-group > :global(.dss-btn:focus) {
+		z-index: 1;
+	}
+</style>

--- a/src/lib/svelte/ui/ButtonGroup.svelte
+++ b/src/lib/svelte/ui/ButtonGroup.svelte
@@ -17,16 +17,16 @@
 	}
 
 	.dss-button-group > :global(.dss-btn:first-child) {
-		border-radius: var(--dss-radius-sm, 6px) 0 0 var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px) 0 0 var(--radius-sm, 6px);
 		margin-left: 0;
 	}
 
 	.dss-button-group > :global(.dss-btn:last-child) {
-		border-radius: 0 var(--dss-radius-sm, 6px) var(--dss-radius-sm, 6px) 0;
+		border-radius: 0 var(--radius-sm, 6px) var(--radius-sm, 6px) 0;
 	}
 
 	.dss-button-group > :global(.dss-btn:only-child) {
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 	}
 
 	.dss-button-group > :global(.dss-btn:hover),

--- a/src/lib/svelte/ui/Divider.svelte
+++ b/src/lib/svelte/ui/Divider.svelte
@@ -8,7 +8,7 @@
 <style>
 	.dss-divider {
 		flex-shrink: 0;
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 
 	.horizontal {

--- a/src/lib/svelte/ui/Divider.svelte
+++ b/src/lib/svelte/ui/Divider.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	export let orientation: 'horizontal' | 'vertical' = 'horizontal';
+	export let size: 'xs' | 'sm' | 'md' = 'sm';
+</script>
+
+<div class="dss-divider {orientation} size-{size}" role="separator"></div>
+
+<style>
+	.dss-divider {
+		flex-shrink: 0;
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	.horizontal {
+		width: 100%;
+	}
+	.horizontal.size-xs { height: 1px; }
+	.horizontal.size-sm { height: 1px; margin: 4px 0; }
+	.horizontal.size-md { height: 2px; margin: 8px 0; }
+
+	.vertical {
+		height: 100%;
+	}
+	.vertical.size-xs { width: 1px; }
+	.vertical.size-sm { width: 1px; margin: 0 4px; }
+	.vertical.size-md { width: 2px; margin: 0 8px; }
+</style>

--- a/src/lib/svelte/ui/Heading.svelte
+++ b/src/lib/svelte/ui/Heading.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	export let level: 1 | 2 | 3 | 4 | 5 | 6 = 2;
+</script>
+
+{#if level === 1}
+	<h1 class="dss-heading h1"><slot /></h1>
+{:else if level === 2}
+	<h2 class="dss-heading h2"><slot /></h2>
+{:else if level === 3}
+	<h3 class="dss-heading h3"><slot /></h3>
+{:else if level === 4}
+	<h4 class="dss-heading h4"><slot /></h4>
+{:else if level === 5}
+	<h5 class="dss-heading h5"><slot /></h5>
+{:else}
+	<h6 class="dss-heading h6"><slot /></h6>
+{/if}
+
+<style>
+	.dss-heading {
+		margin: 0;
+		color: var(--ssk-colors-text-900, #111827);
+		line-height: 1.3;
+	}
+
+	/* DSS spec: h1=60, h2=52, h3=28, h4=24 — scaled for app UI */
+	.h1 { font-size: 36px; font-weight: 400; }
+	.h2 { font-size: 28px; font-weight: 400; }
+	.h3 { font-size: 22px; font-weight: 700; }
+	.h4 { font-size: 20px; font-weight: 500; }
+	.h5 { font-size: 18px; font-weight: 500; }
+	.h6 { font-size: 16px; font-weight: 500; }
+</style>

--- a/src/lib/svelte/ui/Heading.svelte
+++ b/src/lib/svelte/ui/Heading.svelte
@@ -19,7 +19,7 @@
 <style>
 	.dss-heading {
 		margin: 0;
-		color: var(--ssk-colors-text-900, #111827);
+		color: var(--foreground, #111827);
 		line-height: 1.3;
 	}
 

--- a/src/lib/svelte/ui/Icon.svelte
+++ b/src/lib/svelte/ui/Icon.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import * as icons from 'lucide-svelte';
+	import { iconMap } from './icon-map';
+
+	export let name: string = '';
+	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
+	export let spin: boolean = false;
+	export let cursor: string = '';
+
+	const sizeMap: Record<string, number> = {
+		xs: 12,
+		sm: 16,
+		md: 20,
+		lg: 24,
+		xl: 32
+	};
+
+	$: iconName = iconMap[name] || name;
+	$: IconComponent = (icons as Record<string, any>)[iconName] || null;
+	$: pixelSize = sizeMap[size] || 20;
+</script>
+
+{#if IconComponent}
+	<span
+		class="dss-icon"
+		class:spin
+		style:cursor
+		style:display="inline-flex"
+		style:align-items="center"
+		style:justify-content="center"
+		style:width="{pixelSize}px"
+		style:height="{pixelSize}px"
+		on:click
+		on:keypress
+		role={$$restProps.role || undefined}
+		tabindex={$$restProps.tabindex || undefined}
+	>
+		<svelte:component this={IconComponent} size={pixelSize} />
+	</span>
+{/if}
+
+<style>
+	.dss-icon {
+		display: inline-flex;
+		flex-shrink: 0;
+	}
+
+	.spin {
+		animation: dss-spin 1s linear infinite;
+	}
+
+	@keyframes dss-spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/src/lib/svelte/ui/IconButton.svelte
+++ b/src/lib/svelte/ui/IconButton.svelte
@@ -42,7 +42,7 @@
 		align-items: center;
 		justify-content: center;
 		border: 1px solid transparent;
-		border-radius: var(--dss-radius-sm, 6px);
+		border-radius: var(--radius-sm, 6px);
 		cursor: pointer;
 		transition: background 0.15s, color 0.15s, border-color 0.15s;
 		flex-shrink: 0;
@@ -57,9 +57,9 @@
 
 	/* Primary */
 	.variant-primary {
-		background: var(--ssk-colors-primary-500, #32a9ff);
+		background: var(--primary, #32a9ff);
 		color: white;
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 	}
 	.variant-primary:hover:not(:disabled) {
 		background: var(--ssk-colors-primary-600, #1b8bf5);
@@ -68,12 +68,12 @@
 
 	/* Secondary */
 	.variant-secondary {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-700, #374151);
-		border-color: var(--ssk-colors-neutral-200, #e5e7eb);
+		border-color: var(--border, #e5e7eb);
 	}
 	.variant-secondary:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-200, #e5e7eb);
+		background: var(--border, #e5e7eb);
 	}
 
 	/* Outline */
@@ -92,7 +92,7 @@
 		color: var(--ssk-colors-text-700, #374151);
 	}
 	.variant-ghost:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 	}
 
 	/* Destructive */
@@ -108,7 +108,7 @@
 
 	.dss-icon-btn:focus-visible {
 		outline: none;
-		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--primary, #32a9ff);
 	}
 
 	@keyframes dss-icon-spin {

--- a/src/lib/svelte/ui/IconButton.svelte
+++ b/src/lib/svelte/ui/IconButton.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	export let variant: 'primary' | 'secondary' | 'outline' | 'ghost' | 'destructive' = 'ghost';
+	export let size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+	export let loading: boolean = false;
+	export let disabled: boolean = false;
+	export let ariaLabel: string;
+	export let type: 'button' | 'submit' | 'reset' = 'button';
+
+	const sizeMap: Record<string, string> = {
+		sm: '32px',
+		md: '36px',
+		lg: '40px',
+		xl: '44px'
+	};
+
+	$: dimension = sizeMap[size] || '36px';
+</script>
+
+<button
+	class="dss-icon-btn variant-{variant} size-{size}"
+	style:width={dimension}
+	style:height={dimension}
+	{type}
+	{disabled}
+	aria-label={ariaLabel}
+	aria-busy={loading}
+	on:click
+	on:keypress
+>
+	{#if loading}
+		<svg class="dss-icon-btn-spinner" width="16" height="16" viewBox="0 0 16 16" fill="none">
+			<circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round" />
+		</svg>
+	{:else}
+		<slot />
+	{/if}
+</button>
+
+<style>
+	.dss-icon-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px solid transparent;
+		border-radius: var(--dss-radius-sm, 6px);
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
+		flex-shrink: 0;
+		padding: 0;
+		font-family: inherit;
+	}
+
+	.dss-icon-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	/* Primary */
+	.variant-primary {
+		background: var(--ssk-colors-primary-500, #32a9ff);
+		color: white;
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+	.variant-primary:hover:not(:disabled) {
+		background: var(--ssk-colors-primary-600, #1b8bf5);
+		border-color: var(--ssk-colors-primary-600, #1b8bf5);
+	}
+
+	/* Secondary */
+	.variant-secondary {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-700, #374151);
+		border-color: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+	.variant-secondary:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-200, #e5e7eb);
+	}
+
+	/* Outline */
+	.variant-outline {
+		background: transparent;
+		color: var(--ssk-colors-text-700, #374151);
+		border-color: var(--ssk-colors-neutral-300, #d1d5db);
+	}
+	.variant-outline:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	/* Ghost */
+	.variant-ghost {
+		background: transparent;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.variant-ghost:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+	}
+
+	/* Destructive */
+	.variant-destructive {
+		background: #ef4444;
+		color: white;
+		border-color: #ef4444;
+	}
+	.variant-destructive:hover:not(:disabled) {
+		background: #dc2626;
+		border-color: #dc2626;
+	}
+
+	.dss-icon-btn:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px white, 0 0 0 4px var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	@keyframes dss-icon-spin {
+		to { transform: rotate(360deg); }
+	}
+
+	.dss-icon-btn-spinner {
+		animation: dss-icon-spin 0.8s linear infinite;
+	}
+</style>

--- a/src/lib/svelte/ui/ImagePreview.svelte
+++ b/src/lib/svelte/ui/ImagePreview.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+
+	export let images: { src: string; alt: string; thumbnail?: string }[] = [];
+	export let initialIndex: number = 0;
+
+	const dispatch = createEventDispatcher();
+
+	let lightboxOpen = false;
+	let currentIndex = initialIndex;
+
+	$: currentImage = images[currentIndex] || null;
+	$: counter = `${currentIndex + 1} / ${images.length}`;
+
+	function openLightbox(index: number) {
+		currentIndex = index;
+		lightboxOpen = true;
+	}
+
+	function closeLightbox() {
+		lightboxOpen = false;
+	}
+
+	function prevImage() {
+		currentIndex = currentIndex > 0 ? currentIndex - 1 : images.length - 1;
+	}
+
+	function nextImage() {
+		currentIndex = currentIndex < images.length - 1 ? currentIndex + 1 : 0;
+	}
+
+	function handleBackdropClick(e: MouseEvent) {
+		if ((e.target as HTMLElement).classList.contains('dss-lightbox')) {
+			closeLightbox();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (!lightboxOpen) return;
+		if (e.key === 'Escape') closeLightbox();
+		else if (e.key === 'ArrowLeft') prevImage();
+		else if (e.key === 'ArrowRight') nextImage();
+	}
+
+	onMount(() => document.addEventListener('keydown', handleKeydown));
+	onDestroy(() => document.removeEventListener('keydown', handleKeydown));
+</script>
+
+<div class="dss-imagepreview">
+	<div class="thumbnail-grid">
+		{#each images as image, i}
+			<button
+				type="button"
+				class="thumbnail"
+				on:click={() => openLightbox(i)}
+			>
+				<img src={image.thumbnail || image.src} alt={image.alt} loading="lazy" />
+			</button>
+		{/each}
+	</div>
+
+	{#if lightboxOpen && currentImage}
+		<div class="dss-lightbox" on:click={handleBackdropClick} role="dialog" aria-modal="true">
+			<div class="lightbox-content">
+				<button type="button" class="lightbox-close" on:click={closeLightbox} aria-label="Close">
+					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+						<line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+					</svg>
+				</button>
+
+				{#if images.length > 1}
+					<button type="button" class="lightbox-nav prev" on:click={prevImage} aria-label="Previous">
+						<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<polyline points="15 18 9 12 15 6" />
+						</svg>
+					</button>
+				{/if}
+
+				<img src={currentImage.src} alt={currentImage.alt} class="lightbox-image" />
+
+				{#if images.length > 1}
+					<button type="button" class="lightbox-nav next" on:click={nextImage} aria-label="Next">
+						<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<polyline points="9 18 15 12 9 6" />
+						</svg>
+					</button>
+				{/if}
+
+				{#if images.length > 1}
+					<span class="lightbox-counter">{counter}</span>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dss-imagepreview {
+		font-family: 'Inter', sans-serif;
+	}
+
+	.thumbnail-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+		gap: var(--dss-space-8, 8px);
+	}
+
+	.thumbnail {
+		aspect-ratio: 1;
+		border: 2px solid transparent;
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+		cursor: pointer;
+		padding: 0;
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		transition: border-color 0.15s, transform 0.15s;
+	}
+	.thumbnail:hover {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		transform: scale(1.03);
+	}
+	.thumbnail img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	/* Lightbox */
+	.dss-lightbox {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		background: rgba(0, 0, 0, 0.85);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.lightbox-content {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		padding: 48px;
+	}
+
+	.lightbox-image {
+		max-width: 100%;
+		max-height: 100%;
+		object-fit: contain;
+		border-radius: var(--dss-radius-md, 8px);
+		user-select: none;
+	}
+
+	.lightbox-close {
+		position: absolute;
+		top: 16px;
+		right: 16px;
+		background: rgba(255, 255, 255, 0.15);
+		border: none;
+		color: white;
+		cursor: pointer;
+		padding: 8px;
+		border-radius: var(--dss-radius-full, 9999px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: background 0.15s;
+		z-index: 1;
+	}
+	.lightbox-close:hover {
+		background: rgba(255, 255, 255, 0.25);
+	}
+
+	.lightbox-nav {
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		background: rgba(255, 255, 255, 0.15);
+		border: none;
+		color: white;
+		cursor: pointer;
+		padding: 12px;
+		border-radius: var(--dss-radius-full, 9999px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: background 0.15s;
+		z-index: 1;
+	}
+	.lightbox-nav:hover {
+		background: rgba(255, 255, 255, 0.25);
+	}
+	.lightbox-nav.prev { left: 16px; }
+	.lightbox-nav.next { right: 16px; }
+
+	.lightbox-counter {
+		position: absolute;
+		bottom: 16px;
+		left: 50%;
+		transform: translateX(-50%);
+		color: white;
+		font-size: var(--dss-font-sm, 13px);
+		background: rgba(0, 0, 0, 0.5);
+		padding: 4px 12px;
+		border-radius: var(--dss-radius-full, 9999px);
+		user-select: none;
+	}
+</style>

--- a/src/lib/svelte/ui/ImagePreview.svelte
+++ b/src/lib/svelte/ui/ImagePreview.svelte
@@ -96,7 +96,7 @@
 
 <style>
 	.dss-imagepreview {
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 
 	.thumbnail-grid {
@@ -108,15 +108,15 @@
 	.thumbnail {
 		aspect-ratio: 1;
 		border: 2px solid transparent;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
 		cursor: pointer;
 		padding: 0;
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		transition: border-color 0.15s, transform 0.15s;
 	}
 	.thumbnail:hover {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		transform: scale(1.03);
 	}
 	.thumbnail img {
@@ -151,7 +151,7 @@
 		max-width: 100%;
 		max-height: 100%;
 		object-fit: contain;
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		user-select: none;
 	}
 
@@ -164,7 +164,7 @@
 		color: white;
 		cursor: pointer;
 		padding: 8px;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -184,7 +184,7 @@
 		color: white;
 		cursor: pointer;
 		padding: 12px;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -203,10 +203,10 @@
 		left: 50%;
 		transform: translateX(-50%);
 		color: white;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		background: rgba(0, 0, 0, 0.5);
 		padding: 4px 12px;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		user-select: none;
 	}
 </style>

--- a/src/lib/svelte/ui/Logo.svelte
+++ b/src/lib/svelte/ui/Logo.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	export let srcLogo: string = '';
+	export let altLogo: string = '';
+	export let srcLogoName: string = '';
+	export let altLogoName: string = '';
+	export let fullLogo: boolean = false;
+</script>
+
+<div class="dss-logo">
+	{#if srcLogo}
+		<img src={srcLogo} alt={altLogo} class="logo-icon" />
+	{/if}
+	{#if fullLogo && srcLogoName}
+		<img src={srcLogoName} alt={altLogoName} class="logo-name" />
+	{/if}
+</div>
+
+<style>
+	.dss-logo {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.logo-icon {
+		height: 32px;
+		width: auto;
+	}
+
+	.logo-name {
+		height: 20px;
+		width: auto;
+	}
+</style>

--- a/src/lib/svelte/ui/NumberInput.svelte
+++ b/src/lib/svelte/ui/NumberInput.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: number | undefined = undefined;
+	export let min: number | undefined = undefined;
+	export let max: number | undefined = undefined;
+	export let step: number = 1;
+	export let disabled: boolean = false;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let label: string | undefined = undefined;
+	export let placeholder: string | undefined = undefined;
+	export let error: string | undefined = undefined;
+
+	const dispatch = createEventDispatcher();
+
+	function clamp(val: number): number {
+		if (min !== undefined && val < min) return min;
+		if (max !== undefined && val > max) return max;
+		return val;
+	}
+
+	function update(newValue: number) {
+		const clamped = clamp(newValue);
+		value = clamped;
+		dispatch('change', clamped);
+	}
+
+	function decrement() {
+		if (disabled) return;
+		update((value ?? 0) - step);
+	}
+
+	function increment() {
+		if (disabled) return;
+		update((value ?? 0) + step);
+	}
+
+	function handleInput(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const parsed = parseFloat(target.value);
+		if (!isNaN(parsed)) {
+			update(parsed);
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			increment();
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			decrement();
+		}
+	}
+</script>
+
+{#if label}
+	<label class="dss-number-input-label">{label}</label>
+{/if}
+<div class="dss-number-input size-{size}" class:disabled class:has-error={!!error}>
+	<button
+		class="dss-number-btn decrement"
+		on:click={decrement}
+		{disabled}
+		tabindex="-1"
+		aria-label="Decrease"
+	>
+		<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+			<path d="M2.5 6h7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+		</svg>
+	</button>
+	<input
+		type="text"
+		class="dss-number-field"
+		value={value ?? ''}
+		{placeholder}
+		{disabled}
+		on:input={handleInput}
+		on:keydown={handleKeydown}
+	/>
+	<button
+		class="dss-number-btn increment"
+		on:click={increment}
+		{disabled}
+		tabindex="-1"
+		aria-label="Increase"
+	>
+		<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+			<path d="M6 2.5v7M2.5 6h7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+		</svg>
+	</button>
+</div>
+{#if error}
+	<span class="dss-number-input-error">{error}</span>
+{/if}
+
+<style>
+	.dss-number-input-label {
+		display: block;
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+		margin-bottom: var(--dss-space-4, 4px);
+	}
+
+	.dss-number-input {
+		display: inline-flex;
+		align-items: center;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		overflow: hidden;
+		transition: border-color 0.15s;
+	}
+	.dss-number-input:focus-within {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
+	}
+	.dss-number-input.has-error {
+		border-color: #ef4444;
+	}
+	.dss-number-input.has-error:focus-within {
+		box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
+	}
+	.dss-number-input.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.dss-number-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+		color: var(--ssk-colors-text-500, #6b7280);
+		cursor: pointer;
+		flex-shrink: 0;
+		transition: background 0.15s;
+	}
+	.dss-number-btn:hover:not(:disabled) {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.dss-number-btn:disabled {
+		cursor: not-allowed;
+	}
+
+	.dss-number-field {
+		border: none;
+		outline: none;
+		text-align: center;
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-900, #111827);
+		background: transparent;
+		min-width: 0;
+	}
+
+	/* Sizes */
+	.size-sm .dss-number-btn { width: 28px; height: 28px; }
+	.size-sm .dss-number-field { height: 28px; width: 48px; font-size: 13px; }
+
+	.size-md .dss-number-btn { width: 36px; height: 36px; }
+	.size-md .dss-number-field { height: 36px; width: 60px; font-size: 14px; }
+
+	.size-lg .dss-number-btn { width: 44px; height: 44px; }
+	.size-lg .dss-number-field { height: 44px; width: 72px; font-size: 15px; }
+
+	.dss-number-input-error {
+		display: block;
+		font-size: var(--dss-font-caption, 12px);
+		color: #ef4444;
+		margin-top: var(--dss-space-4, 4px);
+	}
+</style>

--- a/src/lib/svelte/ui/NumberInput.svelte
+++ b/src/lib/svelte/ui/NumberInput.svelte
@@ -97,7 +97,7 @@
 <style>
 	.dss-number-input-label {
 		display: block;
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 		margin-bottom: var(--dss-space-4, 4px);
@@ -107,12 +107,12 @@
 		display: inline-flex;
 		align-items: center;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		overflow: hidden;
 		transition: border-color 0.15s;
 	}
 	.dss-number-input:focus-within {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
 	}
 	.dss-number-input.has-error {
@@ -132,13 +132,13 @@
 		justify-content: center;
 		border: none;
 		background: var(--ssk-colors-neutral-50, #f9fafb);
-		color: var(--ssk-colors-text-500, #6b7280);
+		color: var(--muted-foreground, #6b7280);
 		cursor: pointer;
 		flex-shrink: 0;
 		transition: background 0.15s;
 	}
 	.dss-number-btn:hover:not(:disabled) {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-700, #374151);
 	}
 	.dss-number-btn:disabled {
@@ -149,8 +149,8 @@
 		border: none;
 		outline: none;
 		text-align: center;
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-900, #111827);
+		font-size: var(--text-p, 14px);
+		color: var(--foreground, #111827);
 		background: transparent;
 		min-width: 0;
 	}
@@ -167,7 +167,7 @@
 
 	.dss-number-input-error {
 		display: block;
-		font-size: var(--dss-font-caption, 12px);
+		font-size: var(--text-caption, 12px);
 		color: #ef4444;
 		margin-top: var(--dss-space-4, 4px);
 	}

--- a/src/lib/svelte/ui/ProgressBar.svelte
+++ b/src/lib/svelte/ui/ProgressBar.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	export let value: number = 0;
+	export let max: number = 100;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let color: string | undefined = undefined;
+	export let label: string | undefined = undefined;
+	export let showValue: boolean = false;
+	export let indeterminate: boolean = false;
+
+	$: percentage = Math.min(100, Math.max(0, (value / max) * 100));
+
+	$: fillColor = (() => {
+		if (!color || color === 'primary') return 'var(--ssk-colors-primary-500, #32a9ff)';
+		if (color === 'success') return '#10b981';
+		if (color === 'warning') return '#f59e0b';
+		if (color === 'danger') return '#ef4444';
+		return color;
+	})();
+</script>
+
+<div class="dss-progress-bar size-{size}">
+	{#if label || showValue}
+		<div class="dss-progress-bar-header">
+			{#if label}
+				<span class="dss-progress-bar-label">{label}</span>
+			{/if}
+			{#if showValue && !indeterminate}
+				<span class="dss-progress-bar-value">{Math.round(percentage)}%</span>
+			{/if}
+		</div>
+	{/if}
+	<div class="dss-progress-bar-track" role="progressbar" aria-valuenow={indeterminate ? undefined : value} aria-valuemin={0} aria-valuemax={max}>
+		<div
+			class="dss-progress-bar-fill"
+			class:indeterminate
+			style={indeterminate ? `background: ${fillColor}` : `width: ${percentage}%; background: ${fillColor}`}
+		/>
+	</div>
+</div>
+
+<style>
+	.dss-progress-bar {
+		width: 100%;
+	}
+
+	.dss-progress-bar-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--dss-space-4, 4px);
+	}
+
+	.dss-progress-bar-label {
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.dss-progress-bar-value {
+		font-size: var(--dss-font-caption, 12px);
+		color: var(--ssk-colors-text-500, #6b7280);
+	}
+
+	.dss-progress-bar-track {
+		width: 100%;
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		border-radius: var(--dss-radius-full, 9999px);
+		overflow: hidden;
+	}
+
+	.dss-progress-bar-fill {
+		height: 100%;
+		border-radius: var(--dss-radius-full, 9999px);
+		transition: width 0.3s ease;
+	}
+
+	.dss-progress-bar-fill.indeterminate {
+		width: 40%;
+		animation: dss-progress-slide 1.5s ease-in-out infinite;
+	}
+
+	/* Sizes */
+	.size-sm .dss-progress-bar-track { height: 4px; }
+	.size-sm .dss-progress-bar-fill { height: 4px; }
+
+	.size-md .dss-progress-bar-track { height: 8px; }
+	.size-md .dss-progress-bar-fill { height: 8px; }
+
+	.size-lg .dss-progress-bar-track { height: 12px; }
+	.size-lg .dss-progress-bar-fill { height: 12px; }
+
+	@keyframes dss-progress-slide {
+		0% { transform: translateX(-100%); }
+		100% { transform: translateX(350%); }
+	}
+</style>

--- a/src/lib/svelte/ui/ProgressBar.svelte
+++ b/src/lib/svelte/ui/ProgressBar.svelte
@@ -10,7 +10,7 @@
 	$: percentage = Math.min(100, Math.max(0, (value / max) * 100));
 
 	$: fillColor = (() => {
-		if (!color || color === 'primary') return 'var(--ssk-colors-primary-500, #32a9ff)';
+		if (!color || color === 'primary') return 'var(--primary, #32a9ff)';
 		if (color === 'success') return '#10b981';
 		if (color === 'warning') return '#f59e0b';
 		if (color === 'danger') return '#ef4444';
@@ -51,26 +51,26 @@
 	}
 
 	.dss-progress-bar-label {
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
 
 	.dss-progress-bar-value {
-		font-size: var(--dss-font-caption, 12px);
-		color: var(--ssk-colors-text-500, #6b7280);
+		font-size: var(--text-caption, 12px);
+		color: var(--muted-foreground, #6b7280);
 	}
 
 	.dss-progress-bar-track {
 		width: 100%;
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
-		border-radius: var(--dss-radius-full, 9999px);
+		background: var(--muted, #f3f4f6);
+		border-radius: var(--radius-full, 9999px);
 		overflow: hidden;
 	}
 
 	.dss-progress-bar-fill {
 		height: 100%;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		transition: width 0.3s ease;
 	}
 

--- a/src/lib/svelte/ui/Rating.svelte
+++ b/src/lib/svelte/ui/Rating.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let value: number = 0;
+	export let max: number = 5;
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let disabled: boolean = false;
+	export let readOnly: boolean = false;
+	export let icon: 'star' | 'heart' | 'thumb' = 'star';
+	export let showValue: boolean = false;
+	export let label: string = '';
+
+	const dispatch = createEventDispatcher<{
+		change: number;
+	}>();
+
+	let hoverValue: number = 0;
+
+	$: isInteractive = !disabled && !readOnly;
+	$: displayValue = hoverValue || value;
+
+	function handleClick(index: number) {
+		if (!isInteractive) return;
+		value = index;
+		dispatch('change', index);
+	}
+
+	function handleMouseEnter(index: number) {
+		if (!isInteractive) return;
+		hoverValue = index;
+	}
+
+	function handleMouseLeave() {
+		hoverValue = 0;
+	}
+
+	function handleKeydown(e: KeyboardEvent, index: number) {
+		if (!isInteractive) return;
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			handleClick(index);
+		}
+	}
+</script>
+
+<div class="dss-rating-wrapper" class:disabled>
+	{#if label}
+		<span class="dss-rating-label">{label}</span>
+	{/if}
+
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div
+		class="dss-rating size-{size}"
+		class:readonly={readOnly}
+		on:mouseleave={handleMouseLeave}
+		role={isInteractive ? 'radiogroup' : 'img'}
+		aria-label="Rating: {value} out of {max}"
+	>
+		{#each Array(max) as _, i}
+			{@const starIndex = i + 1}
+			{@const filled = starIndex <= displayValue}
+			<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+			<span
+				class="dss-rating-icon"
+				class:filled
+				class:interactive={isInteractive}
+				on:click={() => handleClick(starIndex)}
+				on:mouseenter={() => handleMouseEnter(starIndex)}
+				on:keydown={(e) => handleKeydown(e, starIndex)}
+				tabindex={isInteractive ? 0 : -1}
+				role="radio"
+				aria-checked={starIndex <= value}
+				aria-label="Rate {starIndex} of {max}"
+			>
+				{#if icon === 'star'}
+					<svg viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+					</svg>
+				{:else if icon === 'heart'}
+					<svg viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+					</svg>
+				{:else if icon === 'thumb'}
+					<svg viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+					</svg>
+				{/if}
+			</span>
+		{/each}
+
+		{#if showValue}
+			<span class="dss-rating-value">{value}</span>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.dss-rating-wrapper {
+		display: inline-flex;
+		flex-direction: column;
+		gap: var(--dss-space-4, 4px);
+		font-family: 'Inter', sans-serif;
+	}
+	.disabled {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
+	.dss-rating-label {
+		font-size: var(--dss-font-label, 13px);
+		font-weight: 500;
+		color: var(--ssk-colors-text-700, #374151);
+	}
+
+	.dss-rating {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+	}
+
+	.dss-rating-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ssk-colors-neutral-300, #d1d5db);
+		transition: transform 0.15s, color 0.15s;
+		outline: none;
+		cursor: default;
+	}
+	.dss-rating-icon.interactive {
+		cursor: pointer;
+	}
+	.dss-rating-icon.interactive:hover {
+		transform: scale(1.15);
+	}
+	.dss-rating-icon:focus-visible {
+		outline: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		outline-offset: 2px;
+		border-radius: 2px;
+	}
+	.dss-rating-icon.filled {
+		color: var(--ssk-colors-primary-500, #32a9ff);
+	}
+
+	.dss-rating-icon svg {
+		display: block;
+	}
+
+	/* Sizes */
+	.size-sm .dss-rating-icon svg { width: 16px; height: 16px; }
+	.size-md .dss-rating-icon svg { width: 22px; height: 22px; }
+	.size-lg .dss-rating-icon svg { width: 28px; height: 28px; }
+
+	.dss-rating-value {
+		font-size: var(--dss-font-sm, 13px);
+		font-weight: 600;
+		color: var(--ssk-colors-text-700, #374151);
+		margin-left: var(--dss-space-4, 4px);
+	}
+</style>

--- a/src/lib/svelte/ui/Rating.svelte
+++ b/src/lib/svelte/ui/Rating.svelte
@@ -99,7 +99,7 @@
 		display: inline-flex;
 		flex-direction: column;
 		gap: var(--dss-space-4, 4px);
-		font-family: 'Inter', sans-serif;
+		font-family: var(--font-label);
 	}
 	.disabled {
 		opacity: 0.5;
@@ -107,7 +107,7 @@
 	}
 
 	.dss-rating-label {
-		font-size: var(--dss-font-label, 13px);
+		font-size: var(--text-label, 13px);
 		font-weight: 500;
 		color: var(--ssk-colors-text-700, #374151);
 	}
@@ -134,12 +134,12 @@
 		transform: scale(1.15);
 	}
 	.dss-rating-icon:focus-visible {
-		outline: 2px solid var(--ssk-colors-primary-500, #32a9ff);
+		outline: 2px solid var(--primary, #32a9ff);
 		outline-offset: 2px;
 		border-radius: 2px;
 	}
 	.dss-rating-icon.filled {
-		color: var(--ssk-colors-primary-500, #32a9ff);
+		color: var(--primary, #32a9ff);
 	}
 
 	.dss-rating-icon svg {
@@ -152,7 +152,7 @@
 	.size-lg .dss-rating-icon svg { width: 28px; height: 28px; }
 
 	.dss-rating-value {
-		font-size: var(--dss-font-sm, 13px);
+		font-size: var(--text-sm, 13px);
 		font-weight: 600;
 		color: var(--ssk-colors-text-700, #374151);
 		margin-left: var(--dss-space-4, 4px);

--- a/src/lib/svelte/ui/Spinner.svelte
+++ b/src/lib/svelte/ui/Spinner.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+
+	const sizeMap = { sm: 16, md: 24, lg: 32 };
+	$: px = sizeMap[size];
+</script>
+
+<svg
+	class="dss-spinner"
+	width={px}
+	height={px}
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.25" stroke-width="3" />
+	<path
+		d="M12 2a10 10 0 0 1 10 10"
+		stroke="currentColor"
+		stroke-width="3"
+		stroke-linecap="round"
+	/>
+</svg>
+
+<style>
+	.dss-spinner {
+		animation: dss-spin 0.8s linear infinite;
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	@keyframes dss-spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/src/lib/svelte/ui/Tag.svelte
+++ b/src/lib/svelte/ui/Tag.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let color: 'default' | 'primary' | 'success' | 'warning' | 'danger' = 'default';
+	export let size: 'sm' | 'md' | 'lg' = 'md';
+	export let closable: boolean = false;
+
+	const dispatch = createEventDispatcher();
+
+	function handleClose() {
+		dispatch('close');
+	}
+</script>
+
+<span class="dss-tag color-{color} size-{size}">
+	<slot name="icon" />
+	<span class="dss-tag-label">
+		<slot />
+	</span>
+	{#if closable}
+		<button class="dss-tag-close" on:click={handleClose} aria-label="Remove">
+			<svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+				<path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+			</svg>
+		</button>
+	{/if}
+</span>
+
+<style>
+	.dss-tag {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		border-radius: var(--dss-radius-full, 9999px);
+		font-weight: 500;
+		white-space: nowrap;
+		line-height: 1;
+	}
+
+	/* Sizes */
+	.size-sm { padding: 2px 8px; font-size: 11px; height: 20px; }
+	.size-md { padding: 3px 10px; font-size: 12px; height: 24px; }
+	.size-lg { padding: 4px 12px; font-size: 13px; height: 28px; }
+
+	/* Colors */
+	.color-default {
+		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		color: var(--ssk-colors-text-700, #374151);
+	}
+	.color-primary {
+		background: var(--ssk-colors-primary-50, #eff8ff);
+		color: var(--ssk-colors-primary-700, #0b6bcb);
+	}
+	.color-success {
+		background: #ecfdf5;
+		color: #065f46;
+	}
+	.color-warning {
+		background: #fffbeb;
+		color: #92400e;
+	}
+	.color-danger {
+		background: #fef2f2;
+		color: #991b1b;
+	}
+
+	.dss-tag-label {
+		display: inline-flex;
+		align-items: center;
+	}
+
+	.dss-tag-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		padding: 0;
+		color: inherit;
+		opacity: 0.6;
+		border-radius: var(--dss-radius-full, 9999px);
+		transition: opacity 0.15s;
+		flex-shrink: 0;
+	}
+	.dss-tag-close:hover {
+		opacity: 1;
+	}
+</style>

--- a/src/lib/svelte/ui/Tag.svelte
+++ b/src/lib/svelte/ui/Tag.svelte
@@ -31,7 +31,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--dss-space-4, 4px);
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		font-weight: 500;
 		white-space: nowrap;
 		line-height: 1;
@@ -44,7 +44,7 @@
 
 	/* Colors */
 	.color-default {
-		background: var(--ssk-colors-neutral-100, #f3f4f6);
+		background: var(--muted, #f3f4f6);
 		color: var(--ssk-colors-text-700, #374151);
 	}
 	.color-primary {
@@ -79,7 +79,7 @@
 		padding: 0;
 		color: inherit;
 		opacity: 0.6;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 		transition: opacity 0.15s;
 		flex-shrink: 0;
 	}

--- a/src/lib/svelte/ui/TagInput.svelte
+++ b/src/lib/svelte/ui/TagInput.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	export let tags: string[] = [];
+	export let placeholder: string = 'Add tag...';
+	export let disabled: boolean = false;
+	export let maxTags: number | undefined = undefined;
+	export let variant: 'default' | 'outlined' = 'default';
+
+	const dispatch = createEventDispatcher();
+
+	let inputValue = '';
+	let inputEl: HTMLInputElement;
+
+	function addTag(text: string) {
+		const trimmed = text.trim();
+		if (!trimmed) return;
+		if (tags.includes(trimmed)) return;
+		if (maxTags !== undefined && tags.length >= maxTags) return;
+		tags = [...tags, trimmed];
+		dispatch('change', tags);
+	}
+
+	function removeTag(index: number) {
+		tags = tags.filter((_, i) => i !== index);
+		dispatch('change', tags);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === ',') {
+			e.preventDefault();
+			const parts = inputValue.split(',');
+			for (const part of parts) {
+				addTag(part);
+			}
+			inputValue = '';
+		} else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+			removeTag(tags.length - 1);
+		}
+	}
+
+	function handleInput() {
+		if (inputValue.includes(',')) {
+			const parts = inputValue.split(',');
+			for (let i = 0; i < parts.length - 1; i++) {
+				addTag(parts[i]);
+			}
+			inputValue = parts[parts.length - 1];
+		}
+	}
+
+	function focusInput() {
+		inputEl?.focus();
+	}
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+	class="dss-tag-input variant-{variant}"
+	class:disabled
+	on:click={focusInput}
+>
+	{#each tags as tag, i}
+		<span class="dss-tag-input-tag">
+			<span class="dss-tag-input-tag-label">{tag}</span>
+			{#if !disabled}
+				<button
+					class="dss-tag-input-tag-close"
+					on:click|stopPropagation={() => removeTag(i)}
+					aria-label="Remove {tag}"
+				>
+					<svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+						<path d="M2.5 2.5l5 5M7.5 2.5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+					</svg>
+				</button>
+			{/if}
+		</span>
+	{/each}
+	<input
+		bind:this={inputEl}
+		bind:value={inputValue}
+		class="dss-tag-input-field"
+		{placeholder}
+		{disabled}
+		on:keydown={handleKeydown}
+		on:input={handleInput}
+	/>
+</div>
+
+<style>
+	.dss-tag-input {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--dss-space-4, 4px);
+		padding: var(--dss-space-4, 4px) var(--dss-space-8, 8px);
+		min-height: 38px;
+		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
+		border-radius: var(--dss-radius-md, 8px);
+		cursor: text;
+		transition: border-color 0.15s;
+	}
+	.dss-tag-input:focus-within {
+		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
+	}
+	.dss-tag-input.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		background: var(--ssk-colors-neutral-50, #f9fafb);
+	}
+
+	.variant-outlined {
+		background: transparent;
+	}
+	.variant-default {
+		background: white;
+	}
+
+	.dss-tag-input-tag {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		background: var(--ssk-colors-primary-50, #eff8ff);
+		color: var(--ssk-colors-primary-700, #0b6bcb);
+		border-radius: var(--dss-radius-sm, 4px);
+		padding: 2px 6px;
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1;
+		height: 24px;
+	}
+
+	.dss-tag-input-tag-label {
+		white-space: nowrap;
+	}
+
+	.dss-tag-input-tag-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		padding: 0;
+		color: inherit;
+		opacity: 0.6;
+		border-radius: var(--dss-radius-full, 9999px);
+	}
+	.dss-tag-input-tag-close:hover {
+		opacity: 1;
+	}
+
+	.dss-tag-input-field {
+		flex: 1;
+		min-width: 60px;
+		border: none;
+		outline: none;
+		font-size: var(--dss-font-body, 14px);
+		color: var(--ssk-colors-text-900, #111827);
+		background: transparent;
+		padding: 4px 0;
+	}
+	.dss-tag-input-field::placeholder {
+		color: var(--ssk-colors-text-400, #9ca3af);
+	}
+</style>

--- a/src/lib/svelte/ui/TagInput.svelte
+++ b/src/lib/svelte/ui/TagInput.svelte
@@ -97,12 +97,12 @@
 		padding: var(--dss-space-4, 4px) var(--dss-space-8, 8px);
 		min-height: 38px;
 		border: 1px solid var(--ssk-colors-neutral-300, #d1d5db);
-		border-radius: var(--dss-radius-md, 8px);
+		border-radius: var(--radius-md, 8px);
 		cursor: text;
 		transition: border-color 0.15s;
 	}
 	.dss-tag-input:focus-within {
-		border-color: var(--ssk-colors-primary-500, #32a9ff);
+		border-color: var(--primary, #32a9ff);
 		box-shadow: 0 0 0 2px var(--ssk-colors-primary-50, #eff8ff);
 	}
 	.dss-tag-input.disabled {
@@ -124,7 +124,7 @@
 		gap: 2px;
 		background: var(--ssk-colors-primary-50, #eff8ff);
 		color: var(--ssk-colors-primary-700, #0b6bcb);
-		border-radius: var(--dss-radius-sm, 4px);
+		border-radius: var(--radius-sm, 4px);
 		padding: 2px 6px;
 		font-size: 12px;
 		font-weight: 500;
@@ -146,7 +146,7 @@
 		padding: 0;
 		color: inherit;
 		opacity: 0.6;
-		border-radius: var(--dss-radius-full, 9999px);
+		border-radius: var(--radius-full, 9999px);
 	}
 	.dss-tag-input-tag-close:hover {
 		opacity: 1;
@@ -157,8 +157,8 @@
 		min-width: 60px;
 		border: none;
 		outline: none;
-		font-size: var(--dss-font-body, 14px);
-		color: var(--ssk-colors-text-900, #111827);
+		font-size: var(--text-p, 14px);
+		color: var(--foreground, #111827);
 		background: transparent;
 		padding: 4px 0;
 	}

--- a/src/lib/svelte/ui/Text.svelte
+++ b/src/lib/svelte/ui/Text.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
+	export let weight: 'normal' | 'medium' | 'semibold' | 'bold' = 'normal';
+	export let color: 'default' | 'neutral' | 'primary' | 'secondary' | 'muted' = 'default';
+</script>
+
+<span class="dss-text size-{size} weight-{weight} color-{color}">
+	<slot />
+</span>
+
+<style>
+	.dss-text {
+		display: inline;
+		line-height: 1.5;
+	}
+
+	/* DSS: button=14, label=18, caption=20, body=24 — mapped to size props */
+	.size-xs { font-size: 12px; }
+	.size-sm { font-size: 14px; }
+	.size-md { font-size: 16px; }
+	.size-lg { font-size: 18px; }
+	.size-xl { font-size: 20px; }
+
+	/* Weights */
+	.weight-normal { font-weight: 400; }
+	.weight-medium { font-weight: 500; }
+	.weight-semibold { font-weight: 600; }
+	.weight-bold { font-weight: 700; }
+
+	/* Colors */
+	.color-default { color: var(--ssk-colors-text-900, #111827); }
+	.color-neutral { color: var(--ssk-colors-neutral-500, #6b7280); }
+	.color-primary { color: var(--ssk-colors-primary-500, #FF8D00); }
+	.color-secondary { color: var(--ssk-colors-secondary-500, #FF0006); }
+	.color-muted { color: var(--ssk-colors-neutral-400, #9ca3af); }
+</style>

--- a/src/lib/svelte/ui/Text.svelte
+++ b/src/lib/svelte/ui/Text.svelte
@@ -28,9 +28,9 @@
 	.weight-bold { font-weight: 700; }
 
 	/* Colors */
-	.color-default { color: var(--ssk-colors-text-900, #111827); }
+	.color-default { color: var(--foreground, #111827); }
 	.color-neutral { color: var(--ssk-colors-neutral-500, #6b7280); }
-	.color-primary { color: var(--ssk-colors-primary-500, #FF8D00); }
+	.color-primary { color: var(--primary, #FF8D00); }
 	.color-secondary { color: var(--ssk-colors-secondary-500, #FF0006); }
 	.color-muted { color: var(--ssk-colors-neutral-400, #9ca3af); }
 </style>

--- a/src/lib/svelte/ui/icon-map.ts
+++ b/src/lib/svelte/ui/icon-map.ts
@@ -1,0 +1,47 @@
+/**
+ * Maps old ssk-icon names to Lucide icon component names.
+ * Used by Icon.svelte to resolve icon references.
+ */
+export const iconMap: Record<string, string> = {
+	// Navigation
+	'outline-bars-3-center-left': 'Menu',
+	'outline-magnifying-glass': 'Search',
+	'outline-arrow-left': 'ArrowLeft',
+
+	// Notification
+	'outline-bell': 'Bell',
+	'outline-envelope': 'Mail',
+	'outline-information-circle': 'Info',
+
+	// Business
+	'outline-building-storefront': 'Store',
+	'outline-shopping-bag': 'ShoppingBag',
+	'outline-chart-bar-square': 'BarChart3',
+	'outline-folder': 'Folder',
+	'outline-wallet': 'Wallet',
+	'outline-banknotes': 'Banknote',
+	'outline-queue-list': 'ListTodo',
+	'outline-truck': 'Truck',
+	'outline-server-stack': 'Server',
+
+	// People
+	'outline-user': 'User',
+	'outline-users': 'Users',
+	'outline-user-plus': 'UserPlus',
+
+	// Actions
+	'outline-plus': 'Plus',
+	'outline-pencil': 'Pencil',
+	'outline-x-mark': 'X',
+	'outline-share': 'Share2',
+	'outline-link': 'Link',
+	'outline-check-circle': 'CheckCircle2',
+	'outline-puzzle-piece': 'Puzzle',
+	'outline-shield-check': 'ShieldCheck',
+	'outline-cog-8-tooth': 'Settings',
+
+	// Solid variants
+	'solid-spinner': 'Loader2',
+	'solid-check-circle': 'CheckCircle2',
+	'solid-arrow-right-on-rectangle': 'LogOut'
+};


### PR DESCRIPTION
## Summary
- เพิ่ม Svelte port ของ DSS components ใน `src/lib/svelte/`
- 19 components ครอบคลุม UI, Layout, Overlay
- ใช้ DSS design tokens เดียวกับ React version

## Components (19 ตัว)

### UI (9)
Button, Avatar, Badge, Heading, Text, Icon, Logo, Spinner, Divider

### Layout (6)
TopNavbar, Sidebar, SidebarHeader, SidebarList, SidebarGroup, SidebarItem

### Overlay (4)
Modal, Dropdown, DropdownOption, ToastContainer

## Structure
```
src/lib/svelte/
├── ui/           # 9 components
├── layout/       # 6 components
├── overlay/      # 4 components
├── styles/       # DSS tokens CSS
├── index.ts      # Barrel export
└── README.md     # Usage docs + TODO
```

## Context
- มาจาก CCS Frontend (Control Center System) ที่เขียน SvelteKit
- Components ผ่านการใช้งานจริงแล้วใน production admin panel
- ไม่กระทบ React components ที่มีอยู่ (แยก folder)

## Related Issues
- #2 Advanced DataTable (Svelte version needed)
- #3 FormField Wrapper
- #4 FilterBar / Toolbar
- #5 PageHeader
- #6 Typography compact mode

## Test plan
- [ ] Verify Svelte components render correctly
- [ ] Verify DSS tokens are applied properly
- [ ] Review component API matches React equivalents
- [ ] Test with SvelteKit project

🤖 Generated with [Claude Code](https://claude.com/claude-code)